### PR TITLE
Refactor CI workflow to use matrix strategy for build/test/lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6.2.0
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
Inspired by https://github.com/noahm/DDRCardDraw/commit/baa7f0ae22fd9d35af230f5f1ef1a4cf26960817, refactors the CI workflow to use a matrix strategy for the build/test/lint commands, rather than Node version. With these changes the three commands run in parallel on separate workers, and with the added fail-fast strategy they will run regardless of failures in the others for improved feedback.