### PR TITLE
Fix share service xss

### DIFF
--- a/scripts/repro/image-template.before.ts
+++ b/scripts/repro/image-template.before.ts
@@ -1,0 +1,1017 @@
+import { PlayData } from '../services/play-data';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { HARD_EX_SCORING_SYSTEM, EX_SCORING_SYSTEM, MONEY_SCORING_SYSTEM } from '@api/utils/scoring';
+import { JUDGMENT_COLORS } from '@api/utils/chartjs-timing-visualizer';
+
+// ITG-specific colors: all Fantastics are blue
+const ITG_JUDGMENT_COLORS: Record<string, string> = {
+  ...JUDGMENT_COLORS,
+  'Fantastic (23ms)': '#21CCE8', // ITG uses blue for all Fantastic windows
+};
+
+/**
+ * Get the judgment color based on scoring system.
+ */
+function getJudgmentColor(judgmentName: string, scoringSystem: string): string {
+  if (scoringSystem?.toLowerCase() === 'itg') {
+    return ITG_JUDGMENT_COLORS[judgmentName] || JUDGMENT_COLORS[judgmentName] || '#666666';
+  }
+  return JUDGMENT_COLORS[judgmentName] || '#666666';
+}
+
+/**
+ * Get a map of which judgment windows are disabled based on the disabledWindows modifier string.
+ */
+function getDisabledWindowsMap(disabledWindows: string | undefined | null): Record<string, boolean> {
+  const value = disabledWindows || '';
+  return {
+    Decent: value === 'Decents + Way Offs' || value === 'Decents',
+    'Way Off': value === 'Decents + Way Offs' || value === 'Way Offs',
+    'Fantastic (10ms)': value === 'Fantastics + Excellents',
+    'Fantastic (15ms)': value === 'Fantastics + Excellents',
+    'Fantastic (23ms)': value === 'Fantastics + Excellents',
+    Excellent: value === 'Fantastics + Excellents',
+  };
+}
+
+const getMisoFontBase64 = (() => {
+  let cached: string | null = null;
+  return () => {
+    if (!cached) {
+      try {
+        const fontPath = join(process.cwd(), 'assets/fonts/miso-light.woff2');
+        const fontBuffer = readFileSync(fontPath);
+        cached = fontBuffer.toString('base64');
+      } catch {
+        console.warn('Failed to load Miso Light font, falling back to system fonts');
+        cached = '';
+      }
+    }
+    return cached;
+  };
+})();
+
+const getNumberFontBase64 = (() => {
+  let cached: string | null = null;
+  return () => {
+    if (!cached) {
+      try {
+        const fontPath = join(process.cwd(), 'assets/fonts/Nunito-VariableFont_wght.woff2');
+        const fontBuffer = readFileSync(fontPath);
+        cached = fontBuffer.toString('base64');
+      } catch {
+        console.warn('Failed to load number font, falling back to system fonts');
+        cached = '';
+      }
+    }
+    return cached;
+  };
+})();
+
+function getGradeImage(grade: string): string {
+  const baseUrl = 'https://assets.arrowcloud.dance/grades/';
+  switch (grade.toLowerCase()) {
+    case 'sex':
+    case 'sext':
+    case 'hex':
+      return `${baseUrl}6star.png`;
+    case 'quint':
+      return `${baseUrl}5star.png`;
+    case 'quad':
+      return `${baseUrl}4star.png`;
+    case 'tristar':
+      return `${baseUrl}3star.png`;
+    case 'twostar':
+      return `${baseUrl}2star.png`;
+    case 'star':
+      return `${baseUrl}star.png`;
+    case 's+':
+      return `${baseUrl}s-plus.png`;
+    case 's':
+      return `${baseUrl}s.png`;
+    case 's-':
+      return `${baseUrl}s-minus.png`;
+    case 'a+':
+      return `${baseUrl}a-plus.png`;
+    case 'a':
+      return `${baseUrl}a.png`;
+    case 'a-':
+      return `${baseUrl}a-minus.png`;
+    case 'b+':
+      return `${baseUrl}b-plus.png`;
+    case 'b':
+      return `${baseUrl}b.png`;
+    case 'b-':
+      return `${baseUrl}b-minus.png`;
+    case 'c+':
+      return `${baseUrl}c-plus.png`;
+    case 'c':
+      return `${baseUrl}c.png`;
+    case 'c-':
+      return `${baseUrl}c-minus.png`;
+    case 'd':
+      return `${baseUrl}d.png`;
+    case 'f':
+      return `${baseUrl}f.png`;
+    default:
+      return `${baseUrl}d.png`;
+  }
+}
+
+function getDifficultyColor(difficulty?: string | null): string {
+  switch (difficulty?.toLowerCase()) {
+    case 'beginner':
+      return '#2563EB'; // blue-600
+    case 'easy':
+      return '#16A34A'; // green-600
+    case 'medium':
+      return '#CA8A04'; // yellow-600
+    case 'hard':
+      return '#EA580C'; // orange-600
+    case 'challenge':
+    case 'expert':
+      return '#DC2626'; // red-600
+    case 'edit':
+      return '#7C3AED'; // violet-600
+    default:
+      return '#4B5563'; // gray-600
+  }
+}
+
+/**
+ * Maps stepsType to a short abbreviation
+ * S = dance-single, D = dance-double, PS = pump-single, PD = pump-double
+ */
+function getStepsTypeAbbrev(stepsType?: string | null): string {
+  switch (stepsType?.toLowerCase()) {
+    case 'dance-single':
+      return 'S';
+    case 'dance-double':
+      return 'D';
+    case 'pump-single':
+      return 'PS';
+    case 'pump-double':
+      return 'PD';
+    case 'dance-couple':
+      return 'DC';
+    case 'dance-routine':
+      return 'DR';
+    case 'lights-cabinet':
+      return 'LC';
+    default:
+      if (stepsType) {
+        const parts = stepsType.split('-');
+        if (parts.length >= 2) {
+          return (parts[0][0] + parts[1][0]).toUpperCase();
+        }
+        return stepsType.slice(0, 2).toUpperCase();
+      }
+      return '?';
+  }
+}
+
+/**
+ * Maps difficulty to a single-letter abbreviation
+ * B = beginner, E = easy, M = medium, H = hard, X = challenge/expert, Ed = edit
+ */
+function getDifficultyAbbrev(difficulty?: string | null): string {
+  switch (difficulty?.toLowerCase()) {
+    case 'beginner':
+      return 'B';
+    case 'easy':
+      return 'E';
+    case 'medium':
+      return 'M';
+    case 'hard':
+      return 'H';
+    case 'challenge':
+    case 'expert':
+      return 'X';
+    case 'edit':
+      return 'Ed';
+    default:
+      return difficulty?.[0]?.toUpperCase() || '?';
+  }
+}
+
+function darkenColor(hex: string, amount: number = 0.6): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.floor((num >> 16) * amount);
+  const g = Math.floor(((num >> 8) & 0x00ff) * amount);
+  const b = Math.floor((num & 0x0000ff) * amount);
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+function getScoringSystemColor(system: string): string {
+  switch (system.toUpperCase()) {
+    case 'H.EX':
+      return '#FF69B4'; // Pink
+    case 'EX':
+      return '#21CCE8'; // Blue
+    case 'ITG':
+    case 'MONEY':
+      return '#FFFFFF'; // White
+    default:
+      return '#21CCE8'; // Default to EX blue
+  }
+}
+
+export async function generateImageHTML(play: PlayData): Promise<string> {
+  const primaryScorePercent = parseFloat(play.primaryScore.score).toFixed(2);
+  const secondaryScorePercent = play.secondaryScore ? parseFloat(play.secondaryScore.score).toFixed(2) : null;
+  const primaryColor = getScoringSystemColor(play.primaryScore.system);
+  const secondaryColor = play.secondaryScore ? getScoringSystemColor(play.secondaryScore.system) : '#FFFFFF';
+
+  // Format date in user's timezone (fallback to UTC)
+  const userTimezone = play.user.timezone || 'UTC';
+  let formattedDate: string;
+  try {
+    formattedDate = new Date(play.createdAt).toLocaleString('en-US', {
+      timeZone: userTimezone,
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  } catch {
+    // Fallback to UTC if timezone is invalid
+    formattedDate = new Date(play.createdAt).toLocaleString('en-US', {
+      timeZone: 'UTC',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }
+
+  // Default gradient - will be replaced by color extraction in image generator
+  const gradientColors = ['#0f172a', '#1e293b'];
+
+  // Select scoring system based on primary system
+  const systemUpper = play.primaryScore.system.toUpperCase();
+  const scoringSystem =
+    systemUpper === 'H.EX' || systemUpper === 'HARDEX'
+      ? HARD_EX_SCORING_SYSTEM
+      : systemUpper === 'ITG' || systemUpper === 'MONEY'
+        ? MONEY_SCORING_SYSTEM
+        : EX_SCORING_SYSTEM;
+
+  const timingWindows = scoringSystem.windows;
+
+  // Order judgments based on the selected system
+  const judgmentOrder = timingWindows.map((w) => w.name).concat(['Miss']);
+
+  // Find the maximum number of digits in any judgment count (minimum 4)
+  const maxDigits = Math.max(
+    4,
+    ...judgmentOrder.filter((j: string) => play.primaryScore.judgments[j] !== undefined).map((j: string) => String(play.primaryScore.judgments[j] || 0).length),
+  );
+
+  // Get disabled windows map from modifiers
+  const disabledWindows = getDisabledWindowsMap(play.modifiers?.disabledWindows);
+
+  const judgmentRows = judgmentOrder
+    .filter((j: string) => play.primaryScore.judgments[j] !== undefined)
+    .map((j: string) => {
+      const count = play.primaryScore.judgments[j] || 0;
+      const isDisabled = disabledWindows[j] || false;
+      const color = isDisabled ? '#555555' : getJudgmentColor(j, play.primaryScore.system);
+      const rowOpacity = isDisabled ? 'opacity: 0.5;' : '';
+      const countStr = String(count);
+      const paddingNeeded = maxDigits - countStr.length;
+
+      // When disabled, leading zeros use same color as digits (no highlight distinction)
+      const leadingZeroColor = isDisabled ? color : darkenColor(color, 0.25);
+
+      let displayValue = '';
+      if (paddingNeeded > 0) {
+        const leadingZeros = '0'.repeat(paddingNeeded);
+        displayValue = leadingZeros
+          .split('')
+          .map((d) => `<span class="digit" style="color: ${leadingZeroColor};">${d}</span>`)
+          .join('');
+      }
+      displayValue += countStr
+        .split('')
+        .map((d) => `<span class="digit">${d}</span>`)
+        .join('');
+
+      return `
+        <div class="judgment" style="${rowOpacity}">
+          <span class="judgment-label" style="color: ${color};">${j}</span>
+          <span class="judgment-count" style="color: ${color};">${displayValue}</span>
+        </div>
+      `;
+    })
+    .join('');
+
+  // Prepare timing chart data using the selected system's windows
+  const chartData: { x: number; y: number; color: string }[] = [];
+  const missTimes: number[] = [];
+  if (play.timingData && play.timingData.length > 0) {
+    for (const [t, off] of play.timingData) {
+      if (off === 'Miss') {
+        missTimes.push(t);
+      } else if (typeof off === 'number') {
+        const abs = Math.abs(off);
+        const win = timingWindows.find((w) => abs <= w.maxOffset);
+        const judgmentName = win ? win.name : 'Miss';
+        const color = getJudgmentColor(judgmentName, play.primaryScore.system);
+        chartData.push({ x: t, y: off * 1000, color }); // Convert to ms
+      }
+    }
+  }
+
+  const chartDataJSON = JSON.stringify(chartData);
+  const missTimesJSON = JSON.stringify(missTimes);
+  const npsDataJSON = JSON.stringify(play.npsData || []);
+  const lifebarDataJSON = JSON.stringify(play.lifebarInfo || []);
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <style>
+    ${
+      getMisoFontBase64()
+        ? `
+    @font-face {
+      font-family: 'Miso';
+      src: url(data:font/woff2;base64,${getMisoFontBase64()}) format('woff2');
+      font-weight: 100 900;
+      font-style: normal;
+      font-display: block;
+    }
+    `
+        : ''
+    }
+    ${
+      getNumberFontBase64()
+        ? `
+    @font-face {
+      font-family: 'Azeret Mono';
+      src: url(data:font/woff2;base64,${getNumberFontBase64()}) format('woff2');
+      font-weight: 100 900;
+      font-style: normal;
+      font-display: block;
+    }
+    `
+        : ''
+    }
+    
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    
+    body {
+      width: 880px;
+      height: 800px;
+      background: linear-gradient(135deg, ${gradientColors[0]} 0%, ${gradientColors[1]} 100%);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'Noto Sans JP', sans-serif;
+      color: white;
+      padding: 40px;
+      position: relative;
+      overflow: hidden;
+    }
+    
+    /* Apply Azeret Mono font to all numeric content */
+    ${
+      getNumberFontBase64()
+        ? `
+    .score, .stat-value, .judgment-count, .radar-value, .chart-meta {
+      font-family: 'Azeret Mono', 'Courier New', monospace;
+      font-weight: 600;
+    }
+    `
+        : ''
+    }
+    
+    /* Apply Miso font to labels only */
+    ${
+      getMisoFontBase64()
+        ? `
+    .judgment-label, .stat-label, .radar-label {
+      font-family: 'Miso', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', sans-serif;
+    }
+    `
+        : ''
+    }
+    
+    .user-section {
+      position: absolute;
+      bottom: 25px;
+      right: 40px;
+      width: 280px;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 15px;
+      z-index: 1;
+    }
+    
+    .avatar {
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 255, 255, 0.3);
+      object-fit: cover;
+      background: rgba(255, 255, 255, 0.1);
+    }
+    
+    .user-info h1 {
+      font-size: 20px;
+      font-weight: 700;
+      margin-bottom: 2px;
+      text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+      text-align: right;
+    }
+    
+    .user-info .date {
+      font-size: 12px;
+      opacity: 0.7;
+      font-weight: 400;
+      text-align: right;
+    }
+    
+    .content {
+      display: flex;
+      gap: 40px;
+      align-items: flex-start;
+      position: relative;
+      z-index: 1;
+    }
+    
+    .left-column {
+      width: 480px;
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+    
+    .header-banner {
+      width: 100%;
+      object-fit: cover;
+      border-radius: 8px;
+      box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
+    }
+    
+    .chart-container {
+      width: 100%;
+      height: 220px;
+      background: rgba(0, 0, 0, 0.4);
+      border-radius: 8px;
+      padding: 15px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+    
+    .timing-chart {
+      width: 100% !important;
+      height: 100% !important;
+    }
+    
+    .score-info {
+      display: flex;
+      flex-direction: column;
+      gap: 15px;
+    }
+    
+    .stats {
+      width: 280px;
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 15px;
+    }
+    
+    .score-section {
+      display: flex;
+      align-items: center;
+      gap: 15px;
+      margin-bottom: 0;
+    }
+    
+    .scores-container {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      gap: 20px;
+    }
+    
+    .score-row {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+    }
+    
+    .score-label {
+      font-size: 14px;
+      font-weight: 700;
+      opacity: 0.7;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    
+    .score {
+      font-size: 42px;
+      font-weight: 800;
+      line-height: 1;
+    }
+    
+    .score-secondary {
+      font-size: 28px;
+      font-weight: 700;
+      line-height: 1;
+      opacity: 0.85;
+    }
+    
+    .grade {
+      width: 60px;
+      height: 60px;
+      object-fit: contain;
+      filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.3));
+    }
+    
+    .chart-info {
+      margin-bottom: 20px;
+    }
+    
+    .chart-title {
+      font-size: 24px;
+      font-weight: 700;
+      margin-bottom: 6px;
+      text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);
+    }
+    
+    .chart-artist {
+      font-size: 18px;
+      opacity: 0.8;
+      margin-bottom: 10px;
+    }
+    
+    .chart-meta {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      font-size: 16px;
+    }
+    
+    .difficulty-badge {
+      padding: 5px 14px;
+      border-radius: 6px;
+      font-weight: 700;
+      font-size: 16px;
+      color: white;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    }
+    
+    .steps-type {
+      font-size: 14px;
+      color: #bbb;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    
+    .chart-description {
+      font-size: 14px;
+      color: #aaa;
+      margin-left: 12px;
+    }
+    
+    .chart-credit {
+      font-size: 14px;
+      color: #888;
+      margin-left: 12px;
+    }
+    
+    .stats-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-bottom: 8px;
+      background: rgba(0, 0, 0, 0.3);
+      border-radius: 8px;
+      padding: 15px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    }
+    
+    .stat-item {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    
+    .stat-label {
+      font-size: 16px;
+      opacity: 0.7;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    
+    .stat-value {
+      font-size: 24px;
+      font-weight: 700;
+      color: #ffffff;
+    }
+    
+    .stat-value .unit {
+      font-size: 0.45em;
+      color: #666;
+      margin-left: 2px;
+      font-weight: 400;
+    }
+    
+    .radar-grid {
+      background: rgba(0, 0, 0, 0.3);
+      border-radius: 8px;
+      padding: 8px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    }
+    
+    .radar-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 2px 8px;
+    }
+    
+    .radar-item:last-child {
+      border-bottom: none;
+    }
+    
+    .radar-label {
+      flex: 1;
+      font-weight: 400;
+      opacity: 0.9;
+      font-size: 16px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    
+    .radar-value {
+      font-weight: 800;
+      font-size: 20px;
+      min-width: 80px;
+      text-align: right;
+      color: #ffffff;
+    }
+    
+    .judgments {
+      background: rgba(0, 0, 0, 0.3);
+      border-radius: 8px;
+      padding: 4px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    }
+    
+    .judgment {
+      display: flex;
+      align-items: center;
+      font-size: 16px;
+      padding: 0px 8px;
+    }
+    
+    .judgment:last-child {
+      border-bottom: none;
+    }
+    
+    .judgment-label {
+      flex: 1;
+      font-weight: 400;
+      opacity: 0.9;
+      font-size: 20px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    
+    .judgment-count {
+      font-weight: 800;
+      font-size: 36px;
+      min-width: 80px;
+      text-align: right;
+    }
+    
+    .judgment-count .digit {
+      display: inline-block;
+      width: 0.6em;
+      text-align: center;
+    }
+    
+    .footer {
+      position: absolute;
+      bottom: 25px;
+      left: 40px;
+      display: flex;
+      align-items: center;
+      gap: 15px;
+      opacity: 0.7;
+    }
+    
+    .footer-logo {
+      height: 40px;
+      width: auto;
+    }
+    
+    .footer-text {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    
+    .bg-decoration {
+      position: absolute;
+      top: -100px;
+      right: -100px;
+      width: 400px;
+      height: 400px;
+      background: radial-gradient(circle, rgba(96, 165, 250, 0.1) 0%, transparent 70%);
+      border-radius: 50%;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="bg-decoration"></div>
+  
+  <div class="content">
+    <div class="left-column">
+      ${
+        play.chart.bannerUrl
+          ? `<img src="${play.chart.bannerUrl}" alt="${play.chart.title}" class="header-banner" />`
+          : `<div class="header-banner" style="display: flex; align-items: center; justify-content: center; font-size: 48px; opacity: 0.3; background: rgba(255, 255, 255, 0.05); aspect-ratio: 2.56;">🎵</div>`
+      }
+      
+      <div class="score-info">
+        <div class="score-section">
+          ${play.primaryScore.grade ? `<img src="${getGradeImage(play.primaryScore.grade)}" alt="${play.primaryScore.grade}" class="grade" />` : ''}
+          <div class="scores-container">
+            <div class="score-row">
+              <div class="score" style="color: ${primaryColor};">${primaryScorePercent}</div>
+              <span class="score-label" style="color: ${primaryColor};">${play.primaryScore.system}</span>
+            </div>
+            ${
+              secondaryScorePercent
+                ? `
+            <div class="score-row">
+              <div class="score-secondary" style="color: ${secondaryColor};">${secondaryScorePercent}</div>
+              <span class="score-label" style="color: ${secondaryColor};">${play.secondaryScore!.system}</span>
+            </div>
+            `
+                : ''
+            }
+          </div>
+        </div>
+        
+        <div class="chart-info">
+          <div class="chart-title">${play.chart.title}</div>
+          <div class="chart-artist">${play.chart.artist}</div>
+          <div class="chart-meta">
+            ${
+              play.chart.stepsType || play.chart.difficulty || play.chart.meter
+                ? `<span class="difficulty-badge" style="background-color: ${getDifficultyColor(play.chart.difficulty)};">${getStepsTypeAbbrev(play.chart.stepsType)}${getDifficultyAbbrev(play.chart.difficulty)} ${play.chart.meter ?? '?'}</span>`
+                : ''
+            }
+            ${play.chart.description ? `<span class="chart-description">${play.chart.description}</span>` : ''}
+            ${play.chart.credit ? `<span class="chart-credit">${play.chart.credit}</span>` : ''}
+          </div>
+        </div>
+      </div>
+      ${chartData.length > 0 ? '<div class="chart-container"><canvas id="timingChart" class="timing-chart"></canvas></div>' : ''}
+    </div>
+    
+    <div class="stats">
+      ${
+        play.timingStats
+          ? `
+      <div class="stats-grid">
+        <div class="stat-item">
+          <div class="stat-label">Mean Abs.</div>
+          <div class="stat-value">${play.timingStats.meanAbsMs.toFixed(2)}<span class="unit">ms</span></div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-label">Mean Offset</div>
+          <div class="stat-value">${play.timingStats.meanMs.toFixed(2)}<span class="unit">ms</span></div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-label">Std.Dev.^3</div>
+          <div class="stat-value">${(play.timingStats.stdMs * 3).toFixed(2)}<span class="unit">ms</span></div>
+        </div>
+        <div class="stat-item">
+          <div class="stat-label">Max Error</div>
+          <div class="stat-value">${play.timingStats.maxErrMs.toFixed(2)}<span class="unit">ms</span></div>
+        </div>
+      </div>`
+          : ''
+      }
+      
+      <div class="judgments">
+        ${judgmentRows}
+      </div>
+      ${
+        play.radar
+          ? `
+      <div class="radar-grid">
+        <div class="radar-item">
+          <div class="radar-label">Holds Held</div>
+          <div class="radar-value">${play.radar.holdsHeld}/${play.radar.holdsTotal}</div>
+        </div>
+        <div class="radar-item">
+          <div class="radar-label">Rolls Hit</div>
+          <div class="radar-value">${play.radar.rollsHit}/${play.radar.rollsTotal}</div>
+        </div>
+        <div class="radar-item">
+          <div class="radar-label">Mines Dodged</div>
+          <div class="radar-value">${play.radar.minesDodged}/${play.radar.minesTotal}</div>
+        </div>
+      </div>`
+          : ''
+      }
+    </div>
+  </div>
+  
+  <div class="footer">
+    <img src="https://assets.arrowcloud.dance/logos/20250725/ac%20logo.png" alt="Arrow Cloud" class="footer-logo" />
+    <span class="footer-text">arrowcloud.dance/play/${play.id}</span>
+  </div>
+  
+  <div class="user-section">
+    <div class="user-info">
+      <h1>${play.user.alias}</h1>
+      <div class="date">${formattedDate}</div>
+    </div>
+    ${
+      play.user.profileImageUrl
+        ? `<img src="${play.user.profileImageUrl}" alt="${play.user.alias}" class="avatar" />`
+        : `<div class="avatar" style="display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: 700; background: rgba(255, 255, 255, 0.2);">${play.user.alias.charAt(0).toUpperCase()}</div>`
+    }
+  </div>
+  
+  <script>
+    const chartData = ${chartDataJSON};
+    const missTimes = ${missTimesJSON};
+    const npsData = ${npsDataJSON};
+    const lifebarData = ${lifebarDataJSON};
+    
+    if (chartData.length > 0) {
+      const ctx = document.getElementById('timingChart');
+      
+      const datasets = [];
+      const colorGroups = {};
+      
+      let maxAbsY = 0;
+      chartData.forEach(point => {
+        maxAbsY = Math.max(maxAbsY, Math.abs(point.y));
+        if (!colorGroups[point.color]) {
+          colorGroups[point.color] = [];
+        }
+        colorGroups[point.color].push({ x: point.x, y: point.y });
+      });
+      
+      if (npsData.length > 0) {
+        datasets.push({
+          label: 'NPS',
+          data: npsData,
+          type: 'line',
+          fill: 'start',
+          tension: 0.15,
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          borderWidth: 1,
+          borderColor: '#6a0dad99',
+          yAxisID: 'yNps',
+          backgroundColor: (ctx) => {
+            const chart = ctx.chart;
+            const { ctx: c, chartArea } = chart;
+            if (!chartArea) return 'rgba(106,13,173,0.15)';
+            const gradient = c.createLinearGradient(0, chartArea.top, 0, chartArea.bottom);
+            gradient.addColorStop(0, 'rgba(128,0,255,0.15)');
+            gradient.addColorStop(1, 'rgba(0,128,255,0.05)');
+            return gradient;
+          },
+        });
+      }
+      
+      Object.entries(colorGroups).forEach(([color, data]) => {
+        datasets.push({
+          data: data,
+          backgroundColor: color,
+          borderColor: color,
+          pointRadius: 1.5,
+          pointHoverRadius: 1.5,
+          showLine: false,
+        });
+      });
+      
+      const yRange = maxAbsY * 1.2;
+      missTimes.forEach(x => {
+        datasets.push({
+          label: '',
+          data: [
+            { x, y: -yRange },
+            { x, y: yRange },
+          ],
+          backgroundColor: 'rgba(255, 48, 48, 0.4)',
+          borderColor: 'rgba(255, 48, 48, 0.4)',
+          borderWidth: 1,
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          showLine: true,
+          fill: false,
+          type: 'line',
+          tension: 0,
+        });
+      });
+      
+      if (lifebarData.length > 0) {
+        datasets.push({
+          label: 'Lifebar %',
+          data: lifebarData,
+          borderColor: '#FFFFFF',
+          backgroundColor: 'rgba(255, 107, 107, 0.1)',
+          borderWidth: 2,
+          pointRadius: 0,
+          pointHoverRadius: 0,
+          showLine: true,
+          fill: false,
+          type: 'line',
+          yAxisID: 'y1',
+          tension: 0.25,
+        });
+      }
+      
+      new Chart(ctx, {
+        type: 'scatter',
+        data: { datasets },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: { enabled: false },
+          },
+          scales: {
+            x: {
+              type: 'linear',
+              grid: { color: 'rgba(255, 255, 255, 0.05)' },
+              ticks: { display: false }
+            },
+            y: {
+              type: 'linear',
+              min: -maxAbsY * 1.2,
+              max: maxAbsY * 1.2,
+              grid: { 
+                color: (ctx) => {
+                  if (ctx.tick.value === 0) return '#888';
+                  const windows = [15, 23, 44.5, 103.5, 136.5, 181.5];
+                  const val = Math.abs(ctx.tick.value);
+                  if (windows.some(w => Math.abs(w - val) < 1)) {
+                    return 'rgba(255, 255, 255, 0.2)';
+                  }
+                  return 'rgba(255, 255, 255, 0.05)';
+                }
+              },
+              ticks: { display: false }
+            },
+            yNps: {
+              type: 'linear',
+              display: false,
+              position: 'right',
+              grid: { display: false },
+            },
+            y1: {
+              type: 'linear',
+              display: false,
+              position: 'right',
+              min: 0,
+              max: 100,
+              grid: { display: false },
+            }
+          },
+          layout: {
+            padding: {
+              top: 5,
+              right: 0,
+              bottom: 0,
+              left: 0
+            }
+          }
+        }
+      });
+    }
+  </script>
+</body>
+</html>`;
+}

--- a/scripts/repro/render-share-before-after.ts
+++ b/scripts/repro/render-share-before-after.ts
@@ -1,0 +1,52 @@
+/**
+ * Render the share-service template with a malicious chart payload using BOTH
+ * the pre-fix (HEAD) version and the current (fixed) version, write each HTML
+ * to disk, then write a tiny harness for Playwright to load them.
+ *
+ * Run from repo root:
+ *   npx tsx --tsconfig share-service/tsconfig.json scripts/repro/render-share-before-after.ts
+ */
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+import { generateImageHTML as generateFixed } from '../../share-service/src/utils/image-template';
+import { generateImageHTML as generateBefore } from './image-template.before';
+
+const POPUP_ARTIST =
+  '</div><div id="injected-popup" style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;border:1px solid #888;border-radius:6px;padding:18px 22px;box-shadow:0 12px 48px rgba(0,0,0,.55);font:14px system-ui,sans-serif;color:#000;z-index:99999;min-width:340px"><div style="font-weight:600;font-size:15px;margin-bottom:6px">arrow-cloud.local says</div><div style="margin-bottom:14px">XSS via chart metadata</div><div style="text-align:right"><span style="display:inline-block;background:#1a73e8;color:#fff;padding:6px 18px;border-radius:3px">OK</span></div></div><div>';
+
+const fakePlay: any = {
+  id: 1,
+  user: { id: 'u', alias: 'tester', profileImageUrl: null },
+  chart: {
+    bannerUrl: null,
+    title: 'InjectionChart',
+    artist: POPUP_ARTIST,
+    description: 'pwn',
+    credit: '',
+    stepsType: 'dance-single',
+    difficulty: 'Beginner',
+    meter: 1,
+  },
+  primaryScore: { system: 'EX', percent: 0, grade: null, judgments: {} },
+  secondaryScore: null,
+  timingStats: null,
+  timingData: [],
+  radar: null,
+  playedAt: new Date().toISOString(),
+  modifiers: null,
+};
+
+(async () => {
+  const outDir = 'D:/github/arrow-cloud/share-service/.repro-out';
+  mkdirSync(outDir, { recursive: true });
+
+  const beforeHtml = await generateBefore(fakePlay);
+  const afterHtml = await generateFixed(fakePlay);
+
+  writeFileSync(join(outDir, 'before.html'), beforeHtml);
+  writeFileSync(join(outDir, 'after.html'), afterHtml);
+
+  console.log('wrote', outDir + '/before.html  (', beforeHtml.length, 'bytes )');
+  console.log('wrote', outDir + '/after.html   (', afterHtml.length, 'bytes )');
+})();

--- a/scripts/repro/verify-share-escape.ts
+++ b/scripts/repro/verify-share-escape.ts
@@ -1,0 +1,94 @@
+/**
+ * Local verification that escapeHtml/safeUrl neutralize the injection payloads
+ * we built earlier. Renders the share-service template with a malicious play
+ * object and checks that the dangerous markup is HTML-encoded (not live).
+ *
+ * Run from repo root:
+ *   npx tsx --tsconfig share-service/tsconfig.json scripts/repro/verify-share-escape.ts
+ */
+import { generateImageHTML } from '../../share-service/src/utils/image-template';
+
+const INJECTION_ARTIST =
+  '</div><div style="position:fixed;top:50%;left:50%;background:#fff;color:#000;padding:18px;z-index:99999">arrow-cloud.local says XSS</div><div>';
+
+const JS_PROOF_ARTIST = '</div><img src=x onerror="document.title=\'PWNED\'"><div>';
+
+const fakePlay: any = {
+  id: 1,
+  user: { id: 'u', alias: 'tester', profileImageUrl: null },
+  chart: {
+    bannerUrl: null,
+    title: 'InjectionChart',
+    artist: INJECTION_ARTIST,
+    description: '<script>alert(1)</script>',
+    credit: '"><img src=x onerror=alert(2)>',
+    stepsType: 'dance-single',
+    difficulty: 'Beginner',
+    meter: 1,
+  },
+  primaryScore: { system: 'EX', percent: 0, grade: null, judgments: {} },
+  secondaryScore: null,
+  timingStats: null,
+  timingData: [],
+  radar: null,
+  playedAt: new Date().toISOString(),
+  modifiers: null,
+};
+
+(async () => {
+  const html = await generateImageHTML(fakePlay);
+
+  const checks = [
+    {
+      label: 'markup-injection ARTIST is encoded',
+      bad: '</div><div style="position:fixed',
+      good: '&lt;/div&gt;&lt;div style=&#61;&quot;position:fixed',
+    },
+    {
+      label: 'js-proof <img onerror> would be encoded if used',
+      bad: '<img src=x onerror=',
+      good: '&lt;img src=x onerror=',
+    },
+    {
+      label: 'description <script> is encoded',
+      bad: '<script>alert(1)</script>',
+      good: '&lt;script&gt;alert(1)&lt;/script&gt;',
+    },
+    {
+      label: 'credit attribute breakout is encoded',
+      bad: '"><img src=x onerror=alert(2)>',
+      good: '&quot;&gt;&lt;img src=x onerror=alert(2)&gt;',
+    },
+  ];
+
+  // Replace artist with the JS-proof payload and re-render to check that case too.
+  const html2 = await generateImageHTML({ ...fakePlay, chart: { ...fakePlay.chart, artist: JS_PROOF_ARTIST } });
+
+  let pass = 0;
+  let fail = 0;
+  for (const c of checks) {
+    const target = c.label.includes('js-proof') ? html2 : html;
+    const live = target.includes(c.bad);
+    // Security property: the dangerous string must not appear verbatim in output.
+    if (!live) {
+      console.log(`  ✓ ${c.label} (payload not rendered as live HTML)`);
+      pass++;
+    } else {
+      console.log(`  ✗ ${c.label} — DANGEROUS: payload rendered live!`);
+      // Show context around the live payload for debugging
+      const idx = target.indexOf(c.bad);
+      console.log(`    context: ...${target.slice(Math.max(0, idx - 40), idx + c.bad.length + 40)}...`);
+      fail++;
+    }
+  }
+  // Sanity: ensure HTML entity encoding was applied somewhere we expect
+  const sawEncoding = html.includes('&lt;') && html.includes('&quot;');
+  console.log(`  ${sawEncoding ? '✓' : '✗'} HTML entity encoding applied to artist/credit`);
+  if (!sawEncoding) fail++;
+  else pass++;
+  console.log(`\n${pass}/${pass + fail} checks passed`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/share-service/src/lambda.ts
+++ b/share-service/src/lambda.ts
@@ -4,6 +4,12 @@ import { fetchSessionData } from './services/session-data';
 import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { escapeHtml, safeUrl } from './utils/escape';
 
+// CSP for the public OG share pages. These pages only embed a single image
+// (the generated share PNG, served from our own infra) and inline <style>.
+// They never need to execute JavaScript, so script-src is locked to 'none'.
+// This is a defense-in-depth backstop on top of HTML escaping in the body.
+const SHARE_PAGE_CSP = "default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
+
 const s3Client = new S3Client();
 
 export const handler = async (event: any) => {
@@ -76,6 +82,9 @@ async function handlePlayPage(event: any) {
     headers: {
       'Content-Type': 'text/html',
       'Cache-Control': 'public, max-age=3600',
+      'Content-Security-Policy': SHARE_PAGE_CSP,
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
     body: `<!DOCTYPE html>
 <html lang="en">
@@ -362,6 +371,9 @@ async function handleSessionPage(event: any) {
     headers: {
       'Content-Type': 'text/html',
       'Cache-Control': 'public, max-age=3600',
+      'Content-Security-Policy': SHARE_PAGE_CSP,
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
     body: `<!DOCTYPE html>
 <html lang="en">

--- a/share-service/src/lambda.ts
+++ b/share-service/src/lambda.ts
@@ -2,6 +2,7 @@ import { generatePlayImage, generateSessionImage } from './services/image-genera
 import { fetchPlayData } from './services/play-data';
 import { fetchSessionData } from './services/session-data';
 import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { escapeHtml, safeUrl } from './utils/escape';
 
 const s3Client = new S3Client();
 
@@ -60,11 +61,15 @@ async function handlePlayPage(event: any) {
   const userName = playData.user.alias || 'Player';
 
   const title = `${userName} - ${songTitle} by ${artist}`;
+  const titleEscaped = escapeHtml(title);
+  const titleAndSiteEscaped = escapeHtml(`${title} - Arrow Cloud`);
 
   // Build image URL
   const baseUrl = event.requestContext?.domainName ? `https://${event.requestContext.domainName}/${event.requestContext.stage}` : '';
   const imageUrl = `${baseUrl}/image/${playId}?p=${primary}&s=${secondary}`;
+  const imageUrlEscaped = escapeHtml(imageUrl);
   const mainSiteUrl = process.env.MAIN_SITE_URL || 'https://arrowcloud.dance';
+  const playLinkEscaped = safeUrl(`${mainSiteUrl}/play/${playId}`);
 
   return {
     statusCode: 200,
@@ -77,15 +82,15 @@ async function handlePlayPage(event: any) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${title} - Arrow Cloud</title>
-  <meta property="og:image" content="${imageUrl}" />
+  <title>${titleAndSiteEscaped}</title>
+  <meta property="og:image" content="${imageUrlEscaped}" />
   <meta property="og:image:width" content="880" />
   <meta property="og:image:height" content="800" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="${title}" />
+  <meta property="og:title" content="${titleEscaped}" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="${imageUrl}" />
-  <meta name="twitter:title" content="${title}" />
+  <meta name="twitter:image" content="${imageUrlEscaped}" />
+  <meta name="twitter:title" content="${titleEscaped}" />
   <style>
     body {
       margin: 0;
@@ -123,9 +128,9 @@ async function handlePlayPage(event: any) {
 </head>
 <body>
   <div class="container">
-    <img src="${imageUrl}" alt="${title}" />
+    <img src="${imageUrlEscaped}" alt="${titleEscaped}" />
     <div class="link">
-      <a href="${mainSiteUrl}/play/${playId}">View on Arrow Cloud →</a>
+      <a href="${playLinkEscaped}">View on Arrow Cloud →</a>
     </div>
   </div>
 </body>
@@ -336,6 +341,8 @@ async function handleSessionPage(event: any) {
   const userName = sessionData.user.alias || 'Player';
   const sessionDate = new Date(sessionData.startedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   const title = `${userName} Session Highlights - ${sessionDate}`;
+  const titleEscaped = escapeHtml(title);
+  const titleAndSiteEscaped = escapeHtml(`${title} - Arrow Cloud`);
 
   // Calculate estimated image dimensions
   // Header ~68px, Info row varies by pack count, Play cards ~150px each + 12px gaps, Footer ~36px, Padding 40px
@@ -346,7 +353,9 @@ async function handleSessionPage(event: any) {
   // Build image URL
   const baseUrl = event.requestContext?.domainName ? `https://${event.requestContext.domainName}/${event.requestContext.stage}` : '';
   const imageUrl = `${baseUrl}/session/image/${sessionId}?plays=${playIds.join(',')}&system=${system}`;
+  const imageUrlEscaped = escapeHtml(imageUrl);
   const mainSiteUrl = process.env.MAIN_SITE_URL || 'https://arrowcloud.dance';
+  const sessionLinkEscaped = safeUrl(`${mainSiteUrl}/session/${sessionId}`);
 
   return {
     statusCode: 200,
@@ -359,15 +368,15 @@ async function handleSessionPage(event: any) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${title} - Arrow Cloud</title>
-  <meta property="og:image" content="${imageUrl}" />
+  <title>${titleAndSiteEscaped}</title>
+  <meta property="og:image" content="${imageUrlEscaped}" />
   <meta property="og:image:width" content="700" />
   <meta property="og:image:height" content="${estimatedHeight}" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="${title}" />
+  <meta property="og:title" content="${titleEscaped}" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="${imageUrl}" />
-  <meta name="twitter:title" content="${title}" />
+  <meta name="twitter:image" content="${imageUrlEscaped}" />
+  <meta name="twitter:title" content="${titleEscaped}" />
   <style>
     body {
       margin: 0;
@@ -405,9 +414,9 @@ async function handleSessionPage(event: any) {
 </head>
 <body>
   <div class="container">
-    <img src="${imageUrl}" alt="${title}" />
+    <img src="${imageUrlEscaped}" alt="${titleEscaped}" />
     <div class="link">
-      <a href="${mainSiteUrl}/session/${sessionId}">View on Arrow Cloud →</a>
+      <a href="${sessionLinkEscaped}">View on Arrow Cloud →</a>
     </div>
   </div>
 </body>

--- a/share-service/src/utils/escape.ts
+++ b/share-service/src/utils/escape.ts
@@ -1,0 +1,53 @@
+/**
+ * HTML escaping utilities for templates that interpolate user-controlled data
+ * into HTML rendered by Puppeteer or returned as a page body.
+ *
+ * Any value that ultimately comes from chart metadata (`#TITLE`, `#ARTIST`,
+ * `#DESCRIPTION`, `#CREDIT`, etc.), user aliases, pack names, or anything else
+ * a user can write into the database MUST go through `escapeHtml` before being
+ * placed into HTML, and through `safeUrl` before being placed into a `src` /
+ * `href` attribute.
+ */
+
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+  '`': '&#96;',
+  '=': '&#61;',
+};
+
+/**
+ * Escape a string for safe interpolation into HTML text or attribute contexts.
+ * Accepts any value; non-strings are coerced. `null`/`undefined` become "".
+ */
+export function escapeHtml(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = typeof value === 'string' ? value : String(value);
+  return str.replace(/[&<>"'`=]/g, (ch) => HTML_ESCAPES[ch]);
+}
+
+/**
+ * Validate that a URL is safe to drop into an `src` / `href` attribute.
+ * Allows http(s) and data:image/* URIs. Anything else (including
+ * `javascript:`, `vbscript:`, malformed URLs, or non-strings) returns the
+ * supplied fallback (default: empty string).
+ *
+ * The returned value is also HTML-attribute-escaped.
+ */
+export function safeUrl(value: unknown, fallback: string = ''): string {
+  if (typeof value !== 'string' || value.length === 0) return escapeHtml(fallback);
+  const trimmed = value.trim();
+  // Reject anything with control characters that could confuse the parser.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(trimmed)) return escapeHtml(fallback);
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('data:image/')) {
+    return escapeHtml(trimmed);
+  }
+  // Protocol-relative URLs (//host/...) are also acceptable; they inherit the page's scheme.
+  if (lower.startsWith('//')) return escapeHtml(trimmed);
+  return escapeHtml(fallback);
+}

--- a/share-service/src/utils/escape.ts
+++ b/share-service/src/utils/escape.ts
@@ -31,9 +31,11 @@ export function escapeHtml(value: unknown): string {
 
 /**
  * Validate that a URL is safe to drop into an `src` / `href` attribute.
- * Allows http(s) and data:image/* URIs. Anything else (including
- * `javascript:`, `vbscript:`, malformed URLs, or non-strings) returns the
- * supplied fallback (default: empty string).
+ *
+ * Allows only `http://` and `https://` URLs. Everything else
+ * (`javascript:`, `vbscript:`, `data:`, `file:`, protocol-relative `//host`,
+ * malformed URLs, non-strings, anything containing control characters)
+ * returns the supplied fallback (default: empty string).
  *
  * The returned value is also HTML-attribute-escaped.
  */
@@ -44,10 +46,8 @@ export function safeUrl(value: unknown, fallback: string = ''): string {
   // eslint-disable-next-line no-control-regex
   if (/[\u0000-\u001f\u007f]/.test(trimmed)) return escapeHtml(fallback);
   const lower = trimmed.toLowerCase();
-  if (lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('data:image/')) {
+  if (lower.startsWith('https://') || lower.startsWith('http://')) {
     return escapeHtml(trimmed);
   }
-  // Protocol-relative URLs (//host/...) are also acceptable; they inherit the page's scheme.
-  if (lower.startsWith('//')) return escapeHtml(trimmed);
   return escapeHtml(fallback);
 }

--- a/share-service/src/utils/image-template.ts
+++ b/share-service/src/utils/image-template.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { HARD_EX_SCORING_SYSTEM, EX_SCORING_SYSTEM, MONEY_SCORING_SYSTEM } from '@api/utils/scoring';
 import { JUDGMENT_COLORS } from '@api/utils/chartjs-timing-visualizer';
+import { escapeHtml, safeUrl } from './escape';
 
 // ITG-specific colors: all Fantastics are blue
 const ITG_JUDGMENT_COLORS: Record<string, string> = {
@@ -750,24 +751,24 @@ export async function generateImageHTML(play: PlayData): Promise<string> {
     <div class="left-column">
       ${
         play.chart.bannerUrl
-          ? `<img src="${play.chart.bannerUrl}" alt="${play.chart.title}" class="header-banner" />`
+          ? `<img src="${safeUrl(play.chart.bannerUrl)}" alt="${escapeHtml(play.chart.title)}" class="header-banner" />`
           : `<div class="header-banner" style="display: flex; align-items: center; justify-content: center; font-size: 48px; opacity: 0.3; background: rgba(255, 255, 255, 0.05); aspect-ratio: 2.56;">🎵</div>`
       }
       
       <div class="score-info">
         <div class="score-section">
-          ${play.primaryScore.grade ? `<img src="${getGradeImage(play.primaryScore.grade)}" alt="${play.primaryScore.grade}" class="grade" />` : ''}
+          ${play.primaryScore.grade ? `<img src="${safeUrl(getGradeImage(play.primaryScore.grade))}" alt="${escapeHtml(play.primaryScore.grade)}" class="grade" />` : ''}
           <div class="scores-container">
             <div class="score-row">
               <div class="score" style="color: ${primaryColor};">${primaryScorePercent}</div>
-              <span class="score-label" style="color: ${primaryColor};">${play.primaryScore.system}</span>
+              <span class="score-label" style="color: ${primaryColor};">${escapeHtml(play.primaryScore.system)}</span>
             </div>
             ${
               secondaryScorePercent
                 ? `
             <div class="score-row">
               <div class="score-secondary" style="color: ${secondaryColor};">${secondaryScorePercent}</div>
-              <span class="score-label" style="color: ${secondaryColor};">${play.secondaryScore!.system}</span>
+              <span class="score-label" style="color: ${secondaryColor};">${escapeHtml(play.secondaryScore!.system)}</span>
             </div>
             `
                 : ''
@@ -776,16 +777,16 @@ export async function generateImageHTML(play: PlayData): Promise<string> {
         </div>
         
         <div class="chart-info">
-          <div class="chart-title">${play.chart.title}</div>
-          <div class="chart-artist">${play.chart.artist}</div>
+          <div class="chart-title">${escapeHtml(play.chart.title)}</div>
+          <div class="chart-artist">${escapeHtml(play.chart.artist)}</div>
           <div class="chart-meta">
             ${
               play.chart.stepsType || play.chart.difficulty || play.chart.meter
-                ? `<span class="difficulty-badge" style="background-color: ${getDifficultyColor(play.chart.difficulty)};">${getStepsTypeAbbrev(play.chart.stepsType)}${getDifficultyAbbrev(play.chart.difficulty)} ${play.chart.meter ?? '?'}</span>`
+                ? `<span class="difficulty-badge" style="background-color: ${getDifficultyColor(play.chart.difficulty)};">${escapeHtml(getStepsTypeAbbrev(play.chart.stepsType))}${escapeHtml(getDifficultyAbbrev(play.chart.difficulty))} ${escapeHtml(play.chart.meter ?? '?')}</span>`
                 : ''
             }
-            ${play.chart.description ? `<span class="chart-description">${play.chart.description}</span>` : ''}
-            ${play.chart.credit ? `<span class="chart-credit">${play.chart.credit}</span>` : ''}
+            ${play.chart.description ? `<span class="chart-description">${escapeHtml(play.chart.description)}</span>` : ''}
+            ${play.chart.credit ? `<span class="chart-credit">${escapeHtml(play.chart.credit)}</span>` : ''}
           </div>
         </div>
       </div>
@@ -849,13 +850,13 @@ export async function generateImageHTML(play: PlayData): Promise<string> {
   
   <div class="user-section">
     <div class="user-info">
-      <h1>${play.user.alias}</h1>
+      <h1>${escapeHtml(play.user.alias)}</h1>
       <div class="date">${formattedDate}</div>
     </div>
     ${
       play.user.profileImageUrl
-        ? `<img src="${play.user.profileImageUrl}" alt="${play.user.alias}" class="avatar" />`
-        : `<div class="avatar" style="display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: 700; background: rgba(255, 255, 255, 0.2);">${play.user.alias.charAt(0).toUpperCase()}</div>`
+        ? `<img src="${safeUrl(play.user.profileImageUrl)}" alt="${escapeHtml(play.user.alias)}" class="avatar" />`
+        : `<div class="avatar" style="display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: 700; background: rgba(255, 255, 255, 0.2);">${escapeHtml(play.user.alias.charAt(0).toUpperCase())}</div>`
     }
   </div>
   

--- a/share-service/src/utils/session-image-template.ts
+++ b/share-service/src/utils/session-image-template.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { HARD_EX_SCORING_SYSTEM, EX_SCORING_SYSTEM, MONEY_SCORING_SYSTEM } from '@api/utils/scoring';
 import { JUDGMENT_COLORS } from '@api/utils/chartjs-timing-visualizer';
+import { escapeHtml, safeUrl } from './escape';
 
 // ITG-specific colors: all Fantastics are blue
 const ITG_JUDGMENT_COLORS: Record<string, string> = {
@@ -291,12 +292,12 @@ function generatePlayCardHTML(play: SessionPlayData, systemColor: string, scorin
       <!-- Column 1: Banner + Chart Info -->
       <div class="col-banner${hasBanner ? '' : ' no-banner'}">
         <div class="banner-container">
-          ${hasBanner ? `<img src="${play.chart.bannerUrl}" alt="${play.chart.title}" class="play-banner" />` : ''}
+          ${hasBanner ? `<img src="${safeUrl(play.chart.bannerUrl)}" alt="${escapeHtml(play.chart.title)}" class="play-banner" />` : ''}
           ${
             hasBanner && hasDifficultyInfo
               ? `
           <div class="difficulty-chip" style="background-color: ${diffColor};">
-            ${getStepsTypeAbbrev(play.chart.stepsType)}${getDifficultyAbbrev(play.chart.difficulty)} ${play.chart.meter}
+            ${escapeHtml(getStepsTypeAbbrev(play.chart.stepsType))}${escapeHtml(getDifficultyAbbrev(play.chart.difficulty))} ${escapeHtml(play.chart.meter)}
           </div>
           `
               : ''
@@ -307,20 +308,20 @@ function generatePlayCardHTML(play: SessionPlayData, systemColor: string, scorin
             !hasBanner && hasDifficultyInfo
               ? `
           <div class="difficulty-chip" style="background-color: ${diffColor};">
-            ${getStepsTypeAbbrev(play.chart.stepsType)}${getDifficultyAbbrev(play.chart.difficulty)} ${play.chart.meter}
+            ${escapeHtml(getStepsTypeAbbrev(play.chart.stepsType))}${escapeHtml(getDifficultyAbbrev(play.chart.difficulty))} ${escapeHtml(play.chart.meter)}
           </div>
           `
               : ''
           }
-          <div class="chart-title">${play.chart.title || 'Unknown'}</div>
-          <div class="chart-artist">${play.chart.artist || 'Unknown Artist'}</div>
+          <div class="chart-title">${escapeHtml(play.chart.title || 'Unknown')}</div>
+          <div class="chart-artist">${escapeHtml(play.chart.artist || 'Unknown Artist')}</div>
         </div>
       </div>
       
       <!-- Column 2: Score/Grade + Scatterplot -->
       <div class="col-score">
         <div class="score-grade">
-          <img src="${getGradeImage(gradeToShow || 'F')}" alt="${gradeToShow || 'F'}" class="grade-image" />
+          <img src="${safeUrl(getGradeImage(gradeToShow || 'F'))}" alt="${escapeHtml(gradeToShow || 'F')}" class="grade-image" />
           <div class="score-text">
             <div class="score-line">
               <span class="score-value" style="color: ${systemColor};">${scorePercent}%</span>
@@ -394,8 +395,8 @@ export function generateSessionImageHTML(session: SessionData): string {
   const topPacksHTML = topPacksForGrid
     .map(
       (pack) => `
-    <div class="pack-grid-item" title="${pack.packName} (${pack.chartCount} chart${pack.chartCount !== 1 ? 's' : ''})">
-      ${pack.bannerUrl ? `<img src="${pack.bannerUrl}" alt="${pack.packName}" class="pack-grid-banner" />` : `<div class="pack-grid-placeholder">📁</div>`}
+    <div class="pack-grid-item" title="${escapeHtml(`${pack.packName} (${pack.chartCount} chart${pack.chartCount !== 1 ? 's' : ''})`)}">
+      ${pack.bannerUrl ? `<img src="${safeUrl(pack.bannerUrl)}" alt="${escapeHtml(pack.packName)}" class="pack-grid-banner" />` : `<div class="pack-grid-placeholder">📁</div>`}
     </div>
   `,
     )
@@ -815,12 +816,12 @@ export function generateSessionImageHTML(session: SessionData): string {
   <div class="header">
     ${
       session.user.profileImageUrl
-        ? `<img src="${session.user.profileImageUrl}" alt="${session.user.alias}" class="avatar" />`
+        ? `<img src="${safeUrl(session.user.profileImageUrl)}" alt="${escapeHtml(session.user.alias)}" class="avatar" />`
         : `<div class="avatar" style="display: flex; align-items: center; justify-content: center; font-size: 18px;">👤</div>`
     }
     <div class="header-info">
       <div class="header-top-row">
-        <h1>${session.user.alias}</h1>
+        <h1>${escapeHtml(session.user.alias)}</h1>
         <span class="session-date">${new Date(session.startedAt).toLocaleDateString('en-US', {
           month: 'short',
           day: 'numeric',


### PR DESCRIPTION
## Summary

Fixes an HTML/JS injection vulnerability in the share-service. User-controlled chart metadata (`#TITLE`, `#ARTIST`, `#DESCRIPTION`, `#CREDIT`, banner URLs), user aliases, profile image URLs, and pack names were interpolated directly into HTML rendered by Puppeteer (and into the OpenGraph share pages returned to viewers). A malicious `.ssc`/`.sm` could break out of the surrounding tags and execute arbitrary HTML/JS in the headless browser or XSS visitors of the share page.

## Impact

Affected three rendered surfaces:

1. **Play share image** — `share-service/src/utils/image-template.ts` → Puppeteer `setContent`
2. **Session highlights image** — `share-service/src/utils/session-image-template.ts` → Puppeteer `setContent`
3. **OpenGraph share pages** — `share-service/src/lambda.ts` for both `/play/{id}` and `/session/{id}` (HTML returned to Discord/Twitter/browser)

A malicious uploader only needed to craft a simfile with `#ARTIST:</div><script>...</script><div>;` (or similar) and get any play/session referencing it shared. Server-side, the script ran inside the headless Chromium during image generation; client-side, viewers loading the share URL had attacker-controlled markup injected into the OG meta and page body.

## Fix

Added a small escape utility in `share-service/src/utils/escape.ts`:

- `escapeHtml(value)` — encodes `& < > " ' \` =` for safe interpolation into HTML text and attribute contexts.
- `safeUrl(value, fallback?)` — restricts `src`/`href` values to `http(s)://`, `data:image/*`, and protocol-relative URLs; rejects `javascript:`, `vbscript:`, control characters, and non-strings. Result is also attribute-escaped.

Applied it to every user-controlled interpolation:

- All `play.chart.*` and `session.user.*` fields
- `play.user.alias`, `play.user.profileImageUrl`
- `pack.packName`, `pack.bannerUrl`
- `primaryScore.system/grade`, `secondaryScore.system`
- The OG `<title>`, `og:title`, `og:image`, `twitter:*` tags and the body `<a href>` in the lambda share pages

## Defense in depth

On top of the escaping fix, the OG share pages returned by `lambda.ts` for `/play/{id}` and `/session/{id}` now send:

- `Content-Security-Policy: default-src 'none'; img-src https: data:; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'` — `script-src` is implicitly `'none'` via `default-src`, so even if HTML escaping in the body regressed, the browser would refuse to execute injected scripts on these pages.
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`

`safeUrl` was also tightened to `http(s)://` only — the `data:image/*` and protocol-relative `//host` branches were never exercised by any caller (every URL that reaches `safeUrl` flows through `assetS3UrlToCloudFrontUrl`, which always produces an absolute http(s) URL).

## Verification

A repro/verification harness is included under `scripts/repro/` (these scripts are local-only — not wired into Lambda or any test runner):

- **`scripts/repro/verify-share-escape.ts`** — renders the template with four injection payloads (markup-breakout artist, `<img onerror>` JS execution, `<script>` in description, attribute-breakout in credit) and asserts none of them appear as live HTML in the output.

  ```
  ✓ markup-injection ARTIST is encoded (payload not rendered as live HTML)
  ✓ js-proof <img onerror> would be encoded if used (payload not rendered as live HTML)
  ✓ description <script> is encoded (payload not rendered as live HTML)
  ✓ credit attribute breakout is encoded (payload not rendered as live HTML)
  ✓ HTML entity encoding applied to artist/credit
  5/5 checks passed
  ```

- **`scripts/repro/render-share-before-after.ts`** — writes pre-fix and post-fix HTML to disk for visual diffing.
- **`scripts/repro/image-template.before.ts`** — snapshot of the pre-fix template used by the renderer above.

Run with:
```bash
npx tsx --tsconfig share-service/tsconfig.json scripts/repro/verify-share-escape.ts
```

Drove the rendered output through Playwright as well: pre-fix, an injected popup `<div id="injected-popup">` exists in the DOM and is visible on screen; post-fix, no such element exists and the payload renders as literal escaped text inside `.chart-artist`.

---

> 🤖 This PR was developed with AI assistance (GitHub Copilot CLI). Investigation, fix design, implementation, and verification harness were drafted by the assistant and reviewed/directed by the author.
