### PR TITLE
add token renewal

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -33,6 +33,11 @@ const VerifyEmailRequestSchema = z.object({
   token: z.string().min(1, 'Token is required'),
 });
 
+const RenewTokenSchema = z.object({
+  // Mirrors the "remember me" choice so the renewed token keeps the same lifetime.
+  rememberMe: z.boolean().optional().default(true),
+});
+
 const RequestPasswordResetSchema = z.object({
   email: z.string().email('Invalid email format'),
 });
@@ -159,6 +164,34 @@ export const login = async (event: APIGatewayProxyEvent, prisma: PrismaClient): 
     return respond(200, response);
   } catch (error) {
     console.error('Login error:', error);
+    return internalServerErrorResponse();
+  }
+};
+
+/**
+ * Issue a fresh JWT for an already-authenticated user. Used by the client to
+ * extend an active session (activity-based renewal) without forcing a re-login.
+ */
+export const renewToken = async (event: AuthenticatedEvent, prisma: PrismaClient): Promise<APIGatewayProxyResult> => {
+  try {
+    let rememberMe = true;
+    if (event.body) {
+      const validationResult = RenewTokenSchema.safeParse(JSON.parse(event.body));
+      if (!validationResult.success) {
+        return respond(422, {
+          error: 'Validation failed',
+          issues: validationResult.error?.issues,
+        });
+      }
+      rememberMe = validationResult.data.rememberMe;
+    }
+
+    const token = await generateJwtToken(event.user.id, event.user.email, rememberMe);
+    const permissions = await resolveUserPermissions(prisma, event.user.id);
+
+    return respond(200, { token, permissions });
+  } catch (error) {
+    console.error('Token renewal error:', error);
     return internalServerErrorResponse();
   }
 };

--- a/api/src/routes/web.ts
+++ b/api/src/routes/web.ts
@@ -1,5 +1,6 @@
 import {
   login,
+  renewToken,
   register,
   verifyEmail,
   resendVerificationEmail,
@@ -49,6 +50,12 @@ export const webRoutes: Routes = {
     POST: {
       handler: login,
       requiresAuth: false,
+    },
+  },
+  '/auth/renew': {
+    POST: {
+      handler: renewToken,
+      requiresAuth: true,
     },
   },
   '/register': {

--- a/api/src/utils/auth.ts
+++ b/api/src/utils/auth.ts
@@ -18,8 +18,8 @@ export const generateJwtToken = async (userId: string, email: string, rememberMe
     iat: Math.floor(Date.now() / 1000),
   };
 
-  // If remember me is false, token expires in 4 hours. If true, expires in 7 days.
-  const expiresIn = rememberMe ? '7d' : '4h';
+  // If remember me is false, token expires in 12 hours. If true, expires in 30 days.
+  const expiresIn = rememberMe ? '30d' : '12h';
 
   return jwt.sign(payload, secret, { expiresIn });
 };

--- a/frontend/src/components/auth/PasskeyButton.tsx
+++ b/frontend/src/components/auth/PasskeyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Fingerprint, Loader2 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { isPasskeySupported, isPlatformPasskeyAvailable } from '../../services/passkey';
@@ -8,13 +8,34 @@ interface PasskeyButtonProps {
   onSuccess?: () => void;
   disabled?: boolean;
   className?: string;
+  /** When true, automatically triggers the passkey prompt once on mount (if a platform passkey is available). */
+  autoPrompt?: boolean;
 }
 
-const PasskeyButton: React.FC<PasskeyButtonProps> = ({ onSuccess, disabled = false, className = '' }) => {
+const PasskeyButton: React.FC<PasskeyButtonProps> = ({ onSuccess, disabled = false, className = '', autoPrompt = false }) => {
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
   const [passkeySupported, setPasskeySupported] = useState(false);
   const [platformAvailable, setPlatformAvailable] = useState(false);
   const { loginWithPasskey } = useAuth();
+  const autoPromptTriggered = useRef(false);
+
+  const handlePasskeyLogin = useCallback(
+    async ({ silent = false }: { silent?: boolean } = {}) => {
+      setIsPasskeyLoading(true);
+      try {
+        // Suppress the global auth error for the automatic prompt so that simply
+        // dismissing it doesn't surface a "cancelled" error on the login page.
+        await loginWithPasskey({ suppressError: silent });
+        onSuccess?.();
+      } catch (error) {
+        // Error is handled by auth context
+        console.error('Passkey login failed:', error);
+      } finally {
+        setIsPasskeyLoading(false);
+      }
+    },
+    [loginWithPasskey, onSuccess],
+  );
 
   useEffect(() => {
     const checkSupport = async () => {
@@ -28,18 +49,14 @@ const PasskeyButton: React.FC<PasskeyButtonProps> = ({ onSuccess, disabled = fal
     checkSupport();
   }, []);
 
-  const handlePasskeyLogin = async () => {
-    setIsPasskeyLoading(true);
-    try {
-      await loginWithPasskey();
-      onSuccess?.();
-    } catch (error) {
-      // Error is handled by auth context
-      console.error('Passkey login failed:', error);
-    } finally {
-      setIsPasskeyLoading(false);
+  useEffect(() => {
+    // Prompt immediately on page load rather than waiting for a button click.
+    // The button stays visible so the user can retry if they dismiss the prompt.
+    if (autoPrompt && passkeySupported && platformAvailable && !autoPromptTriggered.current) {
+      autoPromptTriggered.current = true;
+      handlePasskeyLogin({ silent: true });
     }
-  };
+  }, [autoPrompt, passkeySupported, platformAvailable, handlePasskeyLogin]);
 
   // Don't render if passkeys aren't supported
   if (!passkeySupported) {
@@ -51,7 +68,7 @@ const PasskeyButton: React.FC<PasskeyButtonProps> = ({ onSuccess, disabled = fal
   return (
     <button
       type="button"
-      onClick={handlePasskeyLogin}
+      onClick={() => handlePasskeyLogin()}
       disabled={isDisabled}
       className={`btn btn-outline btn-primary w-full text-lg font-semibold shadow-lg hover:shadow-primary/50 transition-all duration-300 transform hover:scale-[1.02] disabled:transform-none disabled:shadow-none ${className}`}
     >

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback, JSX } from 'react';
+import React, { createContext, useContext, useState, useEffect, useRef, ReactNode, useCallback, JSX } from 'react';
 import {
   login as apiLogin,
   register as apiRegister,
@@ -6,9 +6,10 @@ import {
   resendVerificationEmail as apiResendVerificationEmail,
   getUser as apiGetUser,
   updateProfile as apiUpdateProfile,
+  renewToken as apiRenewToken,
 } from '../services/api';
 import { authenticateWithPasskey } from '../services/passkey';
-import { getStoredToken, storeSession, storeUser, clearSession } from '../services/authStorage';
+import { getStoredToken, storeSession, storeUser, storeToken, clearSession, isPersistentSession, shouldRenewToken } from '../services/authStorage';
 import { UpdateProfileRequest } from '../types/api';
 import { User, AuthResponse } from '../schemas/apiSchemas';
 import { FormattedMessage } from 'react-intl';
@@ -129,6 +130,48 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       window.removeEventListener('auth:logout', handleLogout);
     };
   }, [fetchUserData, logout]);
+
+  const isRenewingRef = useRef(false);
+
+  const renewSessionIfNeeded = useCallback(async () => {
+    const current = getStoredToken();
+    if (!current || !shouldRenewToken(current) || isRenewingRef.current) {
+      return;
+    }
+
+    isRenewingRef.current = true;
+    try {
+      // Preserve the session's persistence (localStorage vs sessionStorage) so the renewed token keeps the same lifetime.
+      const { token: fresh, permissions: freshPermissions } = await apiRenewToken(isPersistentSession());
+      storeToken(fresh);
+      setToken(fresh);
+      if (freshPermissions) {
+        setPermissions(freshPermissions);
+      }
+    } catch (e) {
+      // Non-fatal: a truly expired token is handled by the 401 flow on the next request.
+      console.warn('Token renewal failed:', e);
+    } finally {
+      isRenewingRef.current = false;
+    }
+  }, []);
+
+  // Activity-based session renewal: extend the token on app load and whenever the
+  // tab becomes visible again (covers long-lived sessions that never fully reload).
+  useEffect(() => {
+    if (!user) return;
+
+    renewSessionIfNeeded();
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        renewSessionIfNeeded();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [user, renewSessionIfNeeded]);
 
   const login = async (email: string, password: string, rememberMe: boolean = true): Promise<AuthResponse> => {
     setIsLoading(true);

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
   updateProfile as apiUpdateProfile,
 } from '../services/api';
 import { authenticateWithPasskey } from '../services/passkey';
+import { getStoredToken, storeSession, storeUser, clearSession } from '../services/authStorage';
 import { UpdateProfileRequest } from '../types/api';
 import { User, AuthResponse } from '../schemas/apiSchemas';
 import { FormattedMessage } from 'react-intl';
@@ -17,7 +18,7 @@ interface AuthContextType {
   token: string | null;
   permissions: string[];
   login: (email: string, password: string, rememberMe?: boolean) => Promise<AuthResponse>;
-  loginWithPasskey: () => Promise<AuthResponse>;
+  loginWithPasskey: (options?: { suppressError?: boolean }) => Promise<AuthResponse>;
   register: (email: string, alias: string, password: string) => Promise<AuthResponse>;
   verifyEmail: (token: string) => Promise<AuthResponse>;
   resendVerificationEmail: () => Promise<void>;
@@ -61,8 +62,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setToken(null);
     setPermissions([]);
     setError(null);
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('user');
+    clearSession();
   }, []);
 
   const fetchUserData = useCallback(async (): Promise<void> => {
@@ -70,7 +70,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const data = await apiGetUser();
       setUser(data.user);
       setPermissions(data.user.permissions ?? []);
-      localStorage.setItem('user', JSON.stringify(data.user));
+      storeUser(data.user);
     } catch (error) {
       console.error('Failed to fetch user:', error);
       logout();
@@ -100,7 +100,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   useEffect(() => {
     const initializeAuth = async () => {
-      const storedToken = localStorage.getItem('authToken');
+      const storedToken = getStoredToken();
 
       if (storedToken) {
         setToken(storedToken);
@@ -141,8 +141,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(data.user);
       setPermissions(data.permissions ?? []);
 
-      localStorage.setItem('authToken', data.token);
-      localStorage.setItem('user', JSON.stringify(data.user));
+      // Persist in localStorage when "remember me" is set, otherwise sessionStorage (cleared on tab close).
+      storeSession(data.token, data.user, rememberMe);
       // Immediately hydrate full user (includes rivalUserIds, prefs, permissions)
       try {
         await fetchUserData();
@@ -166,7 +166,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
-  const loginWithPasskey = async (): Promise<AuthResponse> => {
+  const loginWithPasskey = async (options?: { suppressError?: boolean }): Promise<AuthResponse> => {
     setIsLoading(true);
     setError(null);
 
@@ -182,8 +182,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(data.user);
       setPermissions(data.permissions ?? []);
 
-      localStorage.setItem('authToken', data.token);
-      localStorage.setItem('user', JSON.stringify(data.user));
+      storeSession(data.token, data.user, true);
       // Hydrate full user after passkey login
       try {
         await fetchUserData();
@@ -193,7 +192,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       return data;
     } catch (err: any) {
-      setError(err.message || 'Passkey login failed. Please try again.');
+      if (!options?.suppressError) {
+        setError(err.message || 'Passkey login failed. Please try again.');
+      }
       throw err;
     } finally {
       setIsLoading(false);
@@ -211,8 +212,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(data.user);
       setPermissions(data.permissions ?? []);
 
-      localStorage.setItem('authToken', data.token);
-      localStorage.setItem('user', JSON.stringify(data.user));
+      storeSession(data.token, data.user, true);
       // Hydrate full user after registration
       try {
         await fetchUserData();
@@ -247,8 +247,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(data.user);
       setPermissions(data.permissions ?? []);
 
-      localStorage.setItem('authToken', data.token);
-      localStorage.setItem('user', JSON.stringify(data.user));
+      storeSession(data.token, data.user, true);
       // Hydrate full user after email verification
       try {
         await fetchUserData();
@@ -300,7 +299,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       // Update user in state and localStorage
       setUser(response.user);
-      localStorage.setItem('user', JSON.stringify(response.user));
+      storeUser(response.user);
 
       return response.user;
     } catch (err) {
@@ -319,15 +318,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const updateUser = useCallback((userData: User): void => {
     setUser(userData);
-    localStorage.setItem('user', JSON.stringify(userData));
+    storeUser(userData);
   }, []);
 
   const setAuthFromResponse = (authResponse: AuthResponse): void => {
     setToken(authResponse.token);
     setUser(authResponse.user);
     setPermissions(authResponse.permissions ?? []);
-    localStorage.setItem('authToken', authResponse.token);
-    localStorage.setItem('user', JSON.stringify(authResponse.user));
+    storeSession(authResponse.token, authResponse.user, true);
     // Hydrate in the background for flows that call this directly (e.g., reset password)
     fetchUserData().catch((e) => console.warn('Post-auth hydrate failed:', e));
   };

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -148,7 +148,7 @@ interface LoginPageProps {
 export const LoginPage: React.FC<LoginPageProps> = ({ eventMode = false }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [rememberMe, setRememberMe] = useState(false);
+  const [rememberMe, setRememberMe] = useState(true);
   const [showPasskeySetup, setShowPasskeySetup] = useState(false);
   const [preventRedirect, setPreventRedirect] = useState(false);
   const navigate = useNavigate();
@@ -320,7 +320,7 @@ export const LoginPage: React.FC<LoginPageProps> = ({ eventMode = false }) => {
                   <LoginSubmitButton isLoading={isLoading} />
                 </form>
 
-                {!eventMode && <PasskeyButton onSuccess={() => navigate(from, { replace: true })} disabled={isLoading} className="mb-4" />}
+                {!eventMode && <PasskeyButton onSuccess={() => navigate(from, { replace: true })} disabled={isLoading} autoPrompt className="mb-4" />}
 
                 <div className="divider text-base-content/50">
                   <FormattedMessage

--- a/frontend/src/schemas/apiSchemas.ts
+++ b/frontend/src/schemas/apiSchemas.ts
@@ -27,6 +27,11 @@ export const authResponseSchema = z.object({
   permissions: z.array(z.string()).optional(),
 });
 
+export const renewTokenResponseSchema = z.object({
+  token: z.string(),
+  permissions: z.array(z.string()).optional(),
+});
+
 export const getUserResponseSchema = z.object({
   user: userSchema.extend({
     preferredLeaderboards: z.array(z.number()).optional(),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -14,6 +14,7 @@ import {
   authResponseSchema,
   updateProfileResponseSchema,
   passkeysResponseSchema,
+  renewTokenResponseSchema,
   successResponseSchema,
   listPacksResponseSchema,
   listUsersResponseSchema,
@@ -138,6 +139,11 @@ export const verifyEmail = async (data: { token: string }): Promise<ValidatedAut
 
 export const resendVerificationEmail = async (): Promise<void> => {
   await api.post('/resend-verification');
+};
+
+export const renewToken = async (rememberMe: boolean): Promise<{ token: string; permissions?: string[] }> => {
+  const response = await api.post('/auth/renew', { rememberMe });
+  return validateResponse(renewTokenResponseSchema, response.data, '/auth/renew');
 };
 
 export const getUser = async (): Promise<GetUserResponse> => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError } from 'axios';
+import { getStoredToken, clearSession } from './authStorage';
 import {
   LoginRequest,
   RegisterRequest,
@@ -79,7 +80,7 @@ const validateResponse = <T>(schema: any, data: unknown, endpoint: string): T =>
 // Request interceptor to include auth token
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('authToken');
+    const token = getStoredToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -93,8 +94,7 @@ api.interceptors.response.use(
   (response) => response,
   (error: AxiosError) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('authToken');
-      localStorage.removeItem('user');
+      clearSession();
       window.dispatchEvent(new CustomEvent('auth:logout'));
       if (window.location.pathname !== '/login') {
         window.location.href = '/login';

--- a/frontend/src/services/authStorage.ts
+++ b/frontend/src/services/authStorage.ts
@@ -1,0 +1,47 @@
+// Centralized auth session storage.
+//
+// When "Remember me" is checked we persist the session in localStorage so it
+// survives a browser restart. When it's unchecked we use sessionStorage, which
+// is cleared automatically when the tab/window is closed. Reads transparently
+// fall back across both stores so callers don't need to know which one is active.
+
+const TOKEN_KEY = 'authToken';
+const USER_KEY = 'user';
+
+// The store that currently holds the session, defaulting to localStorage when
+// there is no active session yet.
+const activeStore = (): Storage => {
+  if (localStorage.getItem(TOKEN_KEY) !== null) return localStorage;
+  if (sessionStorage.getItem(TOKEN_KEY) !== null) return sessionStorage;
+  return localStorage;
+};
+
+export const getStoredToken = (): string | null => localStorage.getItem(TOKEN_KEY) ?? sessionStorage.getItem(TOKEN_KEY);
+
+export const getStoredUserJson = (): string | null => localStorage.getItem(USER_KEY) ?? sessionStorage.getItem(USER_KEY);
+
+/**
+ * Persist the token and user for a new session.
+ * @param persistent true => localStorage (survives browser restart); false => sessionStorage (cleared when the tab closes).
+ */
+export const storeSession = (token: string, user: unknown, persistent: boolean): void => {
+  const target = persistent ? localStorage : sessionStorage;
+  const other = persistent ? sessionStorage : localStorage;
+  // Ensure the session only lives in one store.
+  other.removeItem(TOKEN_KEY);
+  other.removeItem(USER_KEY);
+  target.setItem(TOKEN_KEY, token);
+  target.setItem(USER_KEY, JSON.stringify(user));
+};
+
+/** Update only the cached user object, in whichever store currently holds the session. */
+export const storeUser = (user: unknown): void => {
+  activeStore().setItem(USER_KEY, JSON.stringify(user));
+};
+
+export const clearSession = (): void => {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+  sessionStorage.removeItem(TOKEN_KEY);
+  sessionStorage.removeItem(USER_KEY);
+};

--- a/frontend/src/services/authStorage.ts
+++ b/frontend/src/services/authStorage.ts
@@ -39,6 +39,39 @@ export const storeUser = (user: unknown): void => {
   activeStore().setItem(USER_KEY, JSON.stringify(user));
 };
 
+/** Replace only the token, in whichever store currently holds the session. */
+export const storeToken = (token: string): void => {
+  activeStore().setItem(TOKEN_KEY, token);
+};
+
+/** Whether the active session is persistent (localStorage / "remember me") vs tab-scoped (sessionStorage). */
+export const isPersistentSession = (): boolean => localStorage.getItem(TOKEN_KEY) !== null;
+
+const decodeJwt = (token: string): { iat?: number; exp?: number } | null => {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return null;
+    const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Whether a token is past the halfway point of its lifetime (and not yet expired),
+ * i.e. worth renewing. Self-scaling: a 30d token renews after 15d, a 12h token after 6h.
+ */
+export const shouldRenewToken = (token: string): boolean => {
+  const claims = decodeJwt(token);
+  if (!claims?.iat || !claims?.exp) return false;
+  const nowSec = Date.now() / 1000;
+  if (nowSec >= claims.exp) return false; // already expired — let the normal 401 flow handle it
+  const lifetime = claims.exp - claims.iat;
+  const elapsed = nowSec - claims.iat;
+  return elapsed >= lifetime / 2;
+};
+
 export const clearSession = (): void => {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(USER_KEY);

--- a/frontend/src/utils/rivalHighlight.tsx
+++ b/frontend/src/utils/rivalHighlight.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Swords, User as UserIcon } from 'lucide-react';
+import { getStoredUserJson } from '../services/authStorage';
 
 export interface HighlightInfo {
   isSelf: boolean;
@@ -12,12 +13,12 @@ export interface HighlightInfo {
 }
 
 /**
- * Safely retrieve the stored authenticated user (and rivals) from localStorage.
+ * Safely retrieve the stored authenticated user (and rivals) from the active session store.
  */
 export function getStoredUser(): { id?: string; rivalUserIds?: string[] } | null {
   if (typeof window === 'undefined') return null;
   try {
-    const json = localStorage.getItem('user');
+    const json = getStoredUserJson();
     if (!json) return null;
     return JSON.parse(json);
   } catch {


### PR DESCRIPTION
Some incremental, and probably more controversial changes on top of #62, adding a token renewal path to the API.

Any client holding a valid token can request a fresh token. Clients will check the age of their token at boot and on `visibilitychange` events. If the token is older than half its total lifetime it will request a new token. In this approach semi-frequent visitors will likely never have to login again.