### PR TITLE
pack leaderboards and streamer widget updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Arrow Cloud
+
+Arrow Cloud is a modern backend supporting In The Groove (ITG) - a rhythm game where players step on arrows with their feet on a dance pad with 4 arrows.
+
+# Structure
+
+This is a mono-repo housing the following:
+1. CDK `/cdk` - AWS IaC
+2. API `/api` - The main API backend. Deployed on AWS Lambda. Mostly bespoke/custom. Uses RDS Postgres for DB with Prisma for ORM/Migrations.
+3. Frontend `/frontend` - A static frontend served by CloudFront. Vite, React, DaisyUI.
+4. Share Service `/share-service` - A frontend distribution that is not static that helps with OpenGraph for share images.
+5. Events `/events` - Micro-sites with frontends and backend APIs using DynamoDB.
+6. Scripts `/scripts` - Small script utilities, some of which are one-off, some have ongoing utility.
+
+# Rules
+
+You are NEVER allowed to:
+- Run migrations
+- Run deployments
+
+These operations will be done manually by a human when required.
+
+# Additional Context
+
+There are README.md files scattered in various places throughout the repo. Reference these for local context where required. Keep the readme files up to date. When context is gained that would be valuable to add at a high level please add additional sections or readme files when appropriate.

--- a/api/src/controllers/chart.ts
+++ b/api/src/controllers/chart.ts
@@ -12,7 +12,7 @@ import { publishScoreSubmissionEvent, EVENT_TYPES } from '../utils/events';
 import { GLOBAL_EX_LEADERBOARD_ID, GLOBAL_MONEY_LEADERBOARD_ID, GLOBAL_HARD_EX_LEADERBOARD_ID } from '../utils/leaderboard';
 import { EventRegistry, EventLeaderboardResponse } from '../utils/events/base';
 import { EventLeaderboardService } from '../services/eventLeaderboards';
-import { notifyWidgetRefresh } from '../utils/websocket';
+import { sendToUser } from '../services/websocket';
 import { resolveChartBanner } from '../utils/chart-banner';
 import { parseLocalDateToUTC } from '../utils/date';
 
@@ -833,16 +833,12 @@ export const scoreSubmission: AuthenticatedRouteHandler = async (event: Authenti
       ]);
 
       // Send immediate WebSocket notification for this user's widgets
-      const WEBSOCKET_API_URL = process.env.WEBSOCKET_API_URL;
-      const CONNECTIONS_TABLE_NAME = process.env.CONNECTIONS_TABLE_NAME || 'arrow-cloud-websocket-connections';
-      if (WEBSOCKET_API_URL) {
-        try {
-          await notifyWidgetRefresh(WEBSOCKET_API_URL, CONNECTIONS_TABLE_NAME, user.id, 'New score submitted');
-          console.log(`[WebSocket] Sent refresh notification for user ${user.id}`);
-        } catch (error) {
-          console.error('[WebSocket] Failed to send refresh notification:', error);
-          // Don't fail the request if WebSocket notification fails
-        }
+      try {
+        await sendToUser(user.id, { type: 'refresh', data: { userId: user.id, reason: 'New score submitted', timestamp: new Date().toISOString() } });
+        console.log(`[WebSocket] Sent refresh notification for user ${user.id}`);
+      } catch (error) {
+        console.error('[WebSocket] Failed to send refresh notification:', error);
+        // Don't fail the request if WebSocket notification fails
       }
 
       // Process the play for leaderboards (pass submission data to avoid S3 fetch)

--- a/api/src/controllers/pack.ts
+++ b/api/src/controllers/pack.ts
@@ -9,6 +9,7 @@ import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 const s3Client = new S3Client();
 import { resolveChartBanner } from '../utils/chart-banner';
 import { GLOBAL_EX_LEADERBOARD_ID, GLOBAL_MONEY_LEADERBOARD_ID, GLOBAL_HARD_EX_LEADERBOARD_ID } from '../utils/leaderboard';
+import { ELIGIBLE_PACK_IDS } from '../utils/pack-leaderboard';
 
 // Query parameter schemas for validation
 const ListPacksQuerySchema = z.object({
@@ -26,6 +27,10 @@ const ListPacksQuerySchema = z.object({
 
   // Filtering
   search: z.string().optional(), // Search in pack name
+  eligibleOnly: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
 
   // Ordering
   orderBy: z.enum(['name', 'createdAt', 'updatedAt', 'simfileCount', 'popularity']).optional().default('popularity'),
@@ -65,7 +70,7 @@ export async function listPacks(event: ExtendedAPIGatewayProxyEvent, prisma: Pri
     const queryParams = event.queryStringParameters || {};
     const validatedQuery = ListPacksQuerySchema.parse(queryParams);
 
-    const { page, limit, search, orderBy, orderDirection } = validatedQuery;
+    const { page, limit, search, eligibleOnly, orderBy, orderDirection } = validatedQuery;
     const skip = (page - 1) * limit;
 
     // Build where clause for filtering
@@ -75,6 +80,9 @@ export async function listPacks(event: ExtendedAPIGatewayProxyEvent, prisma: Pri
         contains: search,
         mode: 'insensitive', // Case-insensitive search
       };
+    }
+    if (eligibleOnly) {
+      where.id = { in: ELIGIBLE_PACK_IDS };
     }
 
     // Build orderBy clause

--- a/api/src/controllers/widget.ts
+++ b/api/src/controllers/widget.ts
@@ -2,352 +2,155 @@ import { APIGatewayProxyResult } from 'aws-lambda';
 import { PrismaClient } from '../../prisma/generated/client';
 import { ExtendedAPIGatewayProxyEvent } from '../utils/types';
 import { respond } from '../utils/responses';
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import {
-  getActiveBlueShiftPhase,
-  BLUE_SHIFT_PHASE_1_HARD_EX_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_1_EX_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_1_MONEY_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_2_HARD_EX_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_2_EX_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_2_MONEY_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_3_HARD_EX_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_3_EX_LEADERBOARD_ID,
-  BLUE_SHIFT_PHASE_3_MONEY_LEADERBOARD_ID,
-  CombinedLeaderboards,
-} from '../utils/events/blueshift';
-import { assetS3UrlToCloudFrontUrl } from '../utils/s3';
+import { assetS3UrlToCloudFrontUrl, S3_BUCKET_ASSETS } from '../utils/s3';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import { resolveChartBanner } from '../utils/chart-banner';
+import { GLOBAL_HARD_EX_LEADERBOARD_ID, GLOBAL_EX_LEADERBOARD_ID, GLOBAL_MONEY_LEADERBOARD_ID } from '../utils/leaderboard';
+import { type ScoringSystemKey, type PackLeaderboardDifficulty } from '../utils/pack-leaderboard';
 
-const S3_BUCKET_ASSETS = process.env.S3_BUCKET_ASSETS || 'arrow-cloud-assets';
+const s3Client = new S3Client();
 
-/**
- * Get leaderboard IDs for the active Blue Shift phase
- */
-function getBlueShiftLeaderboardIds(phaseNumber: 1 | 2 | 3): { hardEX: number; ex: number; itg: number } {
-  switch (phaseNumber) {
-    case 1:
-      return {
-        hardEX: BLUE_SHIFT_PHASE_1_HARD_EX_LEADERBOARD_ID,
-        ex: BLUE_SHIFT_PHASE_1_EX_LEADERBOARD_ID,
-        itg: BLUE_SHIFT_PHASE_1_MONEY_LEADERBOARD_ID,
-      };
-    case 2:
-      return {
-        hardEX: BLUE_SHIFT_PHASE_2_HARD_EX_LEADERBOARD_ID,
-        ex: BLUE_SHIFT_PHASE_2_EX_LEADERBOARD_ID,
-        itg: BLUE_SHIFT_PHASE_2_MONEY_LEADERBOARD_ID,
-      };
-    case 3:
-      return {
-        hardEX: BLUE_SHIFT_PHASE_3_HARD_EX_LEADERBOARD_ID,
-        ex: BLUE_SHIFT_PHASE_3_EX_LEADERBOARD_ID,
-        itg: BLUE_SHIFT_PHASE_3_MONEY_LEADERBOARD_ID,
-      };
-  }
+type LeaderboardKey = 'HardEX' | 'EX' | 'ITG';
+
+type WidgetFeatureConfig =
+  | { type: 'profile' }
+  | { type: 'recentPlays'; leaderboards: LeaderboardKey[] }
+  | { type: 'packLeaderboard'; packId: number; packName: string; difficulty: PackLeaderboardDifficulty; leaderboards: LeaderboardKey[] };
+
+interface WidgetConfig {
+  version: 1;
+  orientation: 'horizontal' | 'vertical';
+  features: WidgetFeatureConfig[];
 }
 
-/**
- * Get S3 key for the current phase's leaderboard data
- */
-function getPhaseS3Key(phaseNumber: 1 | 2 | 3): string {
-  return `json/blueshift-overall-rankings-(phase-${phaseNumber}).json`;
-}
+const LB_KEY_TO_ID: Record<LeaderboardKey, number> = {
+  HardEX: GLOBAL_HARD_EX_LEADERBOARD_ID,
+  EX: GLOBAL_EX_LEADERBOARD_ID,
+  ITG: GLOBAL_MONEY_LEADERBOARD_ID,
+};
 
-/**
- * Fetch leaderboard data from S3
- */
-async function fetchLeaderboardFromS3(s3Key: string): Promise<CombinedLeaderboards | null> {
+function decodeConfig(encoded: string): WidgetConfig | null {
   try {
-    console.log(`Fetching leaderboard from S3: ${S3_BUCKET_ASSETS}/${s3Key}`);
-    const s3Client = new S3Client({});
-    const command = new GetObjectCommand({
-      Bucket: S3_BUCKET_ASSETS,
-      Key: s3Key,
-    });
-
-    const response = await s3Client.send(command);
-    if (!response.Body) {
-      console.error('No body in S3 response');
-      return null;
-    }
-
-    const jsonString = await response.Body.transformToString();
-    const data = JSON.parse(jsonString) as CombinedLeaderboards;
-    console.log(`Successfully fetched S3 data with ${Object.keys(data.leaderboards || {}).length} leaderboards`);
-    return data;
-  } catch (error) {
-    console.error(`Error fetching leaderboard from S3 (${S3_BUCKET_ASSETS}/${s3Key}):`, error);
+    return JSON.parse(Buffer.from(encoded, 'base64').toString('utf-8')) as WidgetConfig;
+  } catch {
     return null;
   }
 }
 
-/**
- * Transform S3 leaderboard data to widget format
- */
-function transformLeaderboardData(
-  combinedData: CombinedLeaderboards,
-  leaderboardType: 'HardEX' | 'EX' | 'ITG',
-  userId: string,
-  rivalUserIds: string[],
-  includeEntries: boolean = true,
-): LeaderboardData {
-  // Map leaderboard type to S3 data key - using simplified keys (hardEX, EX, money)
-  const s3KeyMap: Record<string, string> = {
-    HardEX: 'hardEX',
-    EX: 'EX',
-    ITG: 'money',
-  };
+async function loadPackLeaderboardS3(packId: number): Promise<Record<string, any> | null> {
+  try {
+    const response = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: S3_BUCKET_ASSETS,
+        Key: `json/pack-leaderboards/${packId}.json`,
+      }),
+    );
+    if (!response.Body) return null;
+    const body = await response.Body.transformToString();
+    return JSON.parse(body);
+  } catch (err: any) {
+    if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) return null;
+    console.error(`Error loading pack leaderboard for pack ${packId}:`, err);
+    return null;
+  }
+}
 
-  const s3Key = s3KeyMap[leaderboardType];
-
-  if (!s3Key || !combinedData.leaderboards[s3Key]) {
-    const availableKeys = Object.keys(combinedData.leaderboards);
-    console.warn(`Leaderboard key "${s3Key}" not found for type: ${leaderboardType}. Available keys: ${availableKeys.join(', ')}`);
-    return {
-      stats: {
-        rank: 0,
-        totalPoints: 0,
-        chartsPlayed: 0,
-        totalParticipants: 0,
+async function getRecentPlaysForWidget(userId: string, leaderboardIds: number[], prisma: PrismaClient) {
+  const plays = await prisma.play.findMany({
+    where: {
+      userId,
+      PlayLeaderboard: {
+        some: {
+          leaderboardId: { in: leaderboardIds },
+        },
       },
-      entries: [],
-    };
-  }
-
-  const leaderboard = combinedData.leaderboards[s3Key];
-
-  if (!leaderboard || !leaderboard.rankings) {
-    console.warn(`Leaderboard ${s3Key} not found or has no rankings`);
-    return {
-      stats: {
-        rank: 0,
-        totalPoints: 0,
-        chartsPlayed: 0,
-        totalParticipants: 0,
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+    select: {
+      id: true,
+      createdAt: true,
+      chart: {
+        select: {
+          hash: true,
+          songName: true,
+          artist: true,
+          stepsType: true,
+          difficulty: true,
+          meter: true,
+          simfiles: {
+            orderBy: { createdAt: 'asc' },
+            take: 1,
+            select: {
+              stepsType: true,
+              difficulty: true,
+              meter: true,
+              simfile: {
+                select: {
+                  title: true,
+                  artist: true,
+                  bannerUrl: true,
+                  mdBannerUrl: true,
+                  smBannerUrl: true,
+                  bannerVariants: true,
+                },
+              },
+            },
+          },
+        },
       },
-      entries: [],
-    };
-  }
-
-  const rankings = leaderboard.rankings;
-  const totalParticipants = rankings.length;
-
-  // Find user's ranking
-  const userRanking = rankings.find((r) => r.userId === userId);
-  const userStats: UserStats = userRanking
-    ? {
-        rank: userRanking.rank,
-        totalPoints: userRanking.totalPoints,
-        chartsPlayed: userRanking.chartsPlayed,
-        totalParticipants,
-      }
-    : {
-        rank: 0,
-        totalPoints: 0,
-        chartsPlayed: 0,
-        totalParticipants,
-      };
-
-  // Get smart selection of entries:
-  // - If user has no scores (rank 0): show top 10
-  // - If user has scores: show top 5 rivals, self, and neighbors
-  // - If includeEntries is false: return empty array (stats only)
-  const entries: LeaderboardEntry[] = [];
-
-  if (!includeEntries) {
-    // Only stats requested, no entries needed
-    return {
-      stats: userStats,
-      entries: [],
-    };
-  }
-
-  const addedUserIds = new Set<string>();
-
-  // Helper to create entry
-  const createEntry = (r: (typeof rankings)[0]): LeaderboardEntry => ({
-    rank: r.rank,
-    alias: r.userAlias,
-    points: r.totalPoints,
-    profileImageUrl: r.userProfileImageUrl || null,
-    chartsPlayed: r.chartsPlayed,
-    isSelf: r.userId === userId,
-    isRival: rivalUserIds.includes(r.userId),
+      PlayLeaderboard: {
+        where: { leaderboardId: { in: leaderboardIds } },
+        select: {
+          leaderboard: { select: { type: true } },
+          data: true,
+        },
+      },
+    },
   });
 
-  // If user has no scores (rank 0), just show top 10
-  if (!userRanking || userStats.rank === 0) {
-    const top10 = rankings.slice(0, 10);
-    for (const ranking of top10) {
-      entries.push(createEntry(ranking));
-    }
+  return plays.map((play) => {
+    const chartBanner = resolveChartBanner(play.chart.simfiles as any);
+    const primarySimfile = play.chart.simfiles[0]?.simfile;
     return {
-      stats: userStats,
-      entries,
+      playId: play.id,
+      chart: {
+        hash: play.chart.hash,
+        ...chartBanner,
+        title: primarySimfile?.title ?? play.chart.songName,
+        artist: primarySimfile?.artist ?? play.chart.artist,
+        stepsType: play.chart.stepsType,
+        difficulty: play.chart.difficulty,
+        meter: play.chart.meter,
+      },
+      leaderboards: play.PlayLeaderboard.map((pl: any) => ({
+        leaderboard: pl.leaderboard.type,
+        data: pl.data,
+      })),
+      createdAt: play.createdAt,
     };
-  }
-
-  // Add top 5 rivals
-  const rivals = rankings.filter((r) => rivalUserIds.includes(r.userId)).slice(0, 5);
-  for (const rival of rivals) {
-    entries.push(createEntry(rival));
-    addedUserIds.add(rival.userId);
-  }
-
-  // Find self and neighbors
-  if (userRanking) {
-    const userIndex = rankings.findIndex((r) => r.userId === userId);
-    if (userIndex !== -1) {
-      // Add 2 above (if not already added)
-      for (let i = Math.max(0, userIndex - 2); i < userIndex; i++) {
-        if (!addedUserIds.has(rankings[i].userId)) {
-          entries.push(createEntry(rankings[i]));
-          addedUserIds.add(rankings[i].userId);
-        }
-      }
-
-      // Add self (if not already added)
-      if (!addedUserIds.has(userId)) {
-        entries.push(createEntry(rankings[userIndex]));
-        addedUserIds.add(userId);
-      }
-
-      // Add 2 below (if not already added)
-      for (let i = userIndex + 1; i < Math.min(rankings.length, userIndex + 3); i++) {
-        if (!addedUserIds.has(rankings[i].userId)) {
-          entries.push(createEntry(rankings[i]));
-          addedUserIds.add(rankings[i].userId);
-        }
-      }
-
-      // Fill remaining spots with more neighbors to reach 10
-      if (entries.length < 10) {
-        // Expand search radius around user
-        let radius = 3;
-        while (entries.length < 10 && radius < rankings.length) {
-          // Check above
-          const aboveIndex = userIndex - radius;
-          if (aboveIndex >= 0 && !addedUserIds.has(rankings[aboveIndex].userId)) {
-            entries.push(createEntry(rankings[aboveIndex]));
-            addedUserIds.add(rankings[aboveIndex].userId);
-            if (entries.length >= 10) break;
-          }
-
-          // Check below
-          const belowIndex = userIndex + radius;
-          if (belowIndex < rankings.length && !addedUserIds.has(rankings[belowIndex].userId)) {
-            entries.push(createEntry(rankings[belowIndex]));
-            addedUserIds.add(rankings[belowIndex].userId);
-            if (entries.length >= 10) break;
-          }
-
-          radius++;
-        }
-      }
-    }
-  }
-
-  // Sort by rank
-  entries.sort((a, b) => a.rank - b.rank);
-
-  // Limit to 10
-  const finalEntries = entries.slice(0, 10);
-
-  return {
-    stats: userStats,
-    entries: finalEntries,
-  };
-}
-
-interface LeaderboardEntry {
-  rank: number;
-  alias: string;
-  points: number;
-  profileImageUrl: string | null;
-  chartsPlayed: number;
-  isSelf: boolean;
-  isRival: boolean;
-}
-
-interface UserStats {
-  rank: number;
-  totalPoints: number;
-  chartsPlayed: number;
-  totalParticipants: number;
-}
-
-interface LastPlayedChart {
-  title: string;
-  artist: string;
-  bannerUrl: string;
-  mdBannerUrl?: string;
-  smBannerUrl?: string;
-  bannerVariants?: any;
-  hash: string;
-  difficulty: string;
-  meter: number | null;
-}
-
-interface LastPlayedScore {
-  lastScore: {
-    score: number;
-    grade: string;
-  };
-  pbScore: {
-    score: number;
-    grade: string;
-    rank: number;
-    totalPlayers: number;
-  };
-}
-
-interface LeaderboardData {
-  stats: UserStats;
-  entries: LeaderboardEntry[];
-}
-
-interface WidgetData {
-  user: {
-    id: string;
-    alias: string;
-    profileImageUrl: string | null;
-  };
-  leaderboards?: {
-    HardEX: LeaderboardData;
-    EX: LeaderboardData;
-    ITG: LeaderboardData;
-  };
-  lastPlayed?: {
-    chart: LastPlayedChart;
-    scores: {
-      HardEX: LastPlayedScore;
-      EX: LastPlayedScore;
-      ITG: LastPlayedScore;
-    };
-  } | null;
+  });
 }
 
 /**
- * Get initial widget data for a user
- * GET /web/widget/data?userId={userId}
+ * Get widget data for a user.
+ * GET /widget/data?userId={userId}&config={base64}
  */
 export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma: PrismaClient): Promise<APIGatewayProxyResult> => {
   const userId = event.queryStringParameters?.userId;
-  const featuresParam = event.queryStringParameters?.features;
 
   if (!userId) {
     return respond(400, { error: 'userId is required' });
   }
 
-  // Parse enabled features (default to all)
-  const enabledFeatures = featuresParam ? featuresParam.split(',') : ['main', 'leaderboard', 'lastPlayed'];
-  const showMain = enabledFeatures.includes('main');
-  const showLeaderboard = enabledFeatures.includes('leaderboard');
-  const showLastPlayed = enabledFeatures.includes('lastPlayed');
+  const configEncoded = event.queryStringParameters?.config;
+  const config: WidgetConfig | null = configEncoded ? decodeConfig(configEncoded) : null;
+
+  const recentPlaysFeature = config?.features.find((f): f is Extract<WidgetFeatureConfig, { type: 'recentPlays' }> => f.type === 'recentPlays');
+  const packLeaderboardFeatures =
+    config?.features.filter((f): f is Extract<WidgetFeatureConfig, { type: 'packLeaderboard' }> => f.type === 'packLeaderboard') ?? [];
 
   try {
-    // Get user info (always needed)
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -361,7 +164,37 @@ export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma:
       return respond(404, { error: 'User not found' });
     }
 
-    const widgetData: WidgetData = {
+    const recentPlaysLeaderboardIds = recentPlaysFeature ? recentPlaysFeature.leaderboards.map((k) => LB_KEY_TO_ID[k]) : [];
+
+    const [recentPlays, ...packLeaderboardResults] = await Promise.all([
+      recentPlaysFeature ? getRecentPlaysForWidget(userId, recentPlaysLeaderboardIds, prisma) : Promise.resolve(null),
+      ...packLeaderboardFeatures.map((f) => loadPackLeaderboardS3(f.packId)),
+    ]);
+
+    const packLeaderboards: Record<number, any> = {};
+    packLeaderboardFeatures.forEach((f, i) => {
+      const s3Data = packLeaderboardResults[i];
+      if (!s3Data) {
+        packLeaderboards[f.packId] = { packName: f.packName, leaderboards: {} };
+        return;
+      }
+      const lbData: Record<string, any> = {};
+      for (const lbKey of f.leaderboards) {
+        const systemData = s3Data.leaderboards?.[f.difficulty]?.[lbKey as ScoringSystemKey];
+        if (!systemData) continue;
+        const entry = systemData.rankings?.find((r: any) => r.userId === userId);
+        if (entry) {
+          lbData[lbKey] = {
+            rank: entry.rank,
+            totalScore: entry.totalScore,
+            totalParticipants: systemData.totalParticipants,
+          };
+        }
+      }
+      packLeaderboards[f.packId] = { packName: f.packName, leaderboards: lbData };
+    });
+
+    const response: any = {
       user: {
         id: user.id,
         alias: user.alias,
@@ -369,230 +202,17 @@ export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma:
       },
     };
 
-    // Get active phase
-    const activePhase = getActiveBlueShiftPhase();
-    const leaderboardIds = getBlueShiftLeaderboardIds(activePhase);
-
-    // Fetch leaderboard data from S3 if main, leaderboard, or lastPlayed features are enabled
-    // (lastPlayed needs leaderboard data for stats display)
-    if (showMain || showLeaderboard || showLastPlayed) {
-      const s3Key = getPhaseS3Key(activePhase);
-      const leaderboardData = await fetchLeaderboardFromS3(s3Key);
-
-      if (!leaderboardData) {
-        console.warn(`Failed to fetch S3 leaderboard data for phase ${activePhase}`);
-      }
-
-      if (leaderboardData) {
-        // Get user's rivals
-        const rivals = await prisma.userRival.findMany({
-          where: { userId },
-          select: { rivalUserId: true },
-        });
-        const rivalUserIds = rivals.map((r) => r.rivalUserId);
-
-        // Transform S3 data to widget format
-        // If showLeaderboard is false, we still need stats but don't need entries
-        widgetData.leaderboards = {
-          HardEX: transformLeaderboardData(leaderboardData, 'HardEX', userId, rivalUserIds, showLeaderboard),
-          EX: transformLeaderboardData(leaderboardData, 'EX', userId, rivalUserIds, showLeaderboard),
-          ITG: transformLeaderboardData(leaderboardData, 'ITG', userId, rivalUserIds, showLeaderboard),
-        };
-      }
+    if (recentPlaysFeature) {
+      response.recentPlays = recentPlays;
     }
 
-    // Fetch last played data if enabled
-    if (showLastPlayed) {
-      widgetData.lastPlayed = await fetchLastPlayedData(userId, leaderboardIds, prisma);
+    if (packLeaderboardFeatures.length > 0) {
+      response.packLeaderboards = packLeaderboards;
     }
 
-    return respond(200, widgetData);
+    return respond(200, response);
   } catch (error) {
     console.error('Error fetching widget data:', error);
     return respond(500, { error: 'Failed to fetch widget data' });
   }
 };
-
-/**
- * Fetch last played chart data with scores for all leaderboards
- */
-async function fetchLastPlayedData(
-  userId: string,
-  leaderboardIds: { hardEX: number; ex: number; itg: number },
-  prisma: PrismaClient,
-): Promise<WidgetData['lastPlayed']> {
-  // Get user's most recent play that has Blue Shift leaderboard entries
-  const activeLeaderboardIds = [leaderboardIds.hardEX, leaderboardIds.ex, leaderboardIds.itg];
-
-  const lastPlay = await prisma.play.findFirst({
-    where: {
-      userId,
-      PlayLeaderboard: {
-        some: {
-          leaderboardId: {
-            in: activeLeaderboardIds,
-          },
-        },
-      },
-    },
-    orderBy: { createdAt: 'desc' },
-    include: {
-      chart: true,
-      PlayLeaderboard: {
-        where: {
-          leaderboardId: {
-            in: activeLeaderboardIds,
-          },
-        },
-      },
-    },
-  });
-
-  if (!lastPlay || !lastPlay.chart || lastPlay.PlayLeaderboard.length === 0) {
-    return null;
-  }
-
-  // Get simfile for banner URL and variants
-  const simfileCharts = await prisma.simfileChart.findMany({
-    where: { chartHash: lastPlay.chartHash },
-    orderBy: { createdAt: 'asc' },
-    select: {
-      createdAt: true,
-      simfile: {
-        select: {
-          title: true,
-          artist: true,
-          bannerUrl: true,
-          mdBannerUrl: true,
-          smBannerUrl: true,
-          bannerVariants: true,
-          pack: {
-            select: {
-              bannerUrl: true,
-              mdBannerUrl: true,
-              smBannerUrl: true,
-              bannerVariants: true,
-            },
-          },
-        },
-      },
-    },
-  });
-
-  const primarySimfile = simfileCharts[0]?.simfile;
-  const chartBanner = resolveChartBanner(simfileCharts);
-
-  // Map PlayLeaderboard entries to scores by leaderboard ID
-  const leaderboardMap = new Map(lastPlay.PlayLeaderboard.map((pl) => [pl.leaderboardId, pl]));
-
-  const hardEXEntry = leaderboardMap.get(leaderboardIds.hardEX);
-  const exEntry = leaderboardMap.get(leaderboardIds.ex);
-  const itgEntry = leaderboardMap.get(leaderboardIds.itg);
-
-  // For each leaderboard, get the user's personal best score/grade/rank
-  const getPBData = async (leaderboardId: number) => {
-    const pbData = await prisma.$queryRaw<Array<{ rank: bigint; totalPlayers: bigint; score: number; grade: string }>>`
-      WITH ranked AS (
-        SELECT
-          p."userId",
-          (pl.data->>'score')::decimal AS score,
-          pl.data->>'grade' AS grade,
-          ROW_NUMBER() OVER (
-            PARTITION BY p."userId"
-            ORDER BY pl."sortKey" DESC, p."createdAt" DESC, p.id DESC
-          ) AS rn
-        FROM "PlayLeaderboard" pl
-        JOIN "Play" p ON pl."playId" = p.id
-        WHERE p."chartHash" = ${lastPlay.chartHash}
-          AND pl."leaderboardId" = ${leaderboardId}
-      ),
-      deduped AS (
-        SELECT
-          "userId",
-          score,
-          grade,
-          RANK() OVER (ORDER BY score DESC) AS rank
-        FROM ranked
-        WHERE rn = 1
-      )
-      SELECT
-        d.rank,
-        (SELECT COUNT(*) FROM deduped)::bigint AS "totalPlayers",
-        d.score::numeric AS score,
-        d.grade
-      FROM deduped d
-      WHERE d."userId" = ${userId}
-    `;
-
-    if (pbData.length > 0) {
-      return {
-        rank: Number(pbData[0].rank),
-        totalPlayers: Number(pbData[0].totalPlayers),
-        score: Number(pbData[0].score),
-        grade: pbData[0].grade || 'F',
-      };
-    }
-    return { rank: 0, totalPlayers: 0, score: 0, grade: 'F' };
-  };
-
-  // Fetch PB data for all three leaderboards in parallel
-  const [hardEXPB, exPB, itgPB] = await Promise.all([
-    hardEXEntry ? getPBData(leaderboardIds.hardEX) : Promise.resolve({ rank: 0, totalPlayers: 0, score: 0, grade: 'F' }),
-    exEntry ? getPBData(leaderboardIds.ex) : Promise.resolve({ rank: 0, totalPlayers: 0, score: 0, grade: 'F' }),
-    itgEntry ? getPBData(leaderboardIds.itg) : Promise.resolve({ rank: 0, totalPlayers: 0, score: 0, grade: 'F' }),
-  ]);
-
-  // Helper to extract score data from last play and PB
-  const extractScores = (
-    lastPlayEntry: typeof hardEXEntry,
-    pbData: { rank: number; totalPlayers: number; score: number; grade: string },
-  ): { lastScore: { score: number; grade: string }; pbScore: { score: number; grade: string; rank: number; totalPlayers: number } } => {
-    if (!lastPlayEntry) {
-      return {
-        lastScore: {
-          score: 0,
-          grade: 'F',
-        },
-        pbScore: {
-          score: 0,
-          grade: 'F',
-          rank: 0,
-          totalPlayers: 0,
-        },
-      };
-    }
-
-    const lastPlayData = lastPlayEntry.data as any;
-    return {
-      lastScore: {
-        score: Number(lastPlayData.score) || 0,
-        grade: lastPlayData.grade || 'F',
-      },
-      pbScore: {
-        score: pbData.score,
-        grade: pbData.grade,
-        rank: pbData.rank,
-        totalPlayers: pbData.totalPlayers,
-      },
-    };
-  };
-
-  return {
-    chart: {
-      title: lastPlay.chart.songName || primarySimfile?.title || 'Unknown',
-      artist: lastPlay.chart.artist || primarySimfile?.artist || 'Unknown',
-      bannerUrl: chartBanner.bannerUrl || '',
-      mdBannerUrl: chartBanner.mdBannerUrl || undefined,
-      smBannerUrl: chartBanner.smBannerUrl || undefined,
-      bannerVariants: chartBanner.bannerVariants,
-      hash: lastPlay.chart.hash,
-      difficulty: lastPlay.chart.difficulty || 'Unknown',
-      meter: lastPlay.chart.rating || lastPlay.chart.meter || null,
-    },
-    scores: {
-      HardEX: extractScores(hardEXEntry, hardEXPB),
-      EX: extractScores(exEntry, exPB),
-      ITG: extractScores(itgEntry, itgPB),
-    },
-  };
-}

--- a/api/src/pack-leaderboard.ts
+++ b/api/src/pack-leaderboard.ts
@@ -2,13 +2,9 @@ import type { SQSEvent, SQSHandler, SQSBatchResponse } from 'aws-lambda';
 import { PrismaClient } from '../prisma/generated/client';
 import { ScoreSubmissionEvent, EVENT_TYPES } from './utils/events';
 import { getDatabaseUrl } from './utils/secrets';
-import { calculatePackLeaderboards, type PackLeaderboardOutput } from './utils/pack-leaderboard';
+import { calculatePackLeaderboards, type PackLeaderboardOutput, ELIGIBLE_PACK_IDS } from './utils/pack-leaderboard';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-
-// ---------------------------------------------------------------------------
-// Hard-coded eligible pack IDs — only these packs get leaderboards computed.
-// ---------------------------------------------------------------------------
-const ELIGIBLE_PACK_IDS: number[] = [131];
+import { sendToUser } from './services/websocket';
 
 let prisma: PrismaClient | undefined;
 const s3Client = new S3Client();
@@ -88,6 +84,9 @@ async function processScoreSubmission(event: ScoreSubmissionEvent, prismaClient:
 
       const s3Url = await uploadPackLeaderboard(packId, result);
       console.log(`Pack ${packId} leaderboard uploaded to ${s3Url}`);
+      await sendToUser(userId, { type: 'refresh', data: { userId, reason: 'Pack leaderboard updated', packId, timestamp: new Date().toISOString() } }).catch(
+        (err) => console.error(`[WebSocket] Failed to notify user ${userId} for pack ${packId}:`, err),
+      );
     } catch (error) {
       console.error(`Failed to calculate/upload leaderboard for pack ${packId}:`, error);
       throw error; // Let it bubble up so the SQS message is retried

--- a/api/src/routes/web.ts
+++ b/api/src/routes/web.ts
@@ -419,7 +419,7 @@ export const webRoutes: Routes = {
       },
     },
   },
-  '/widget/blueshift/data': {
+  '/widget/data': {
     GET: {
       handler: getWidgetData,
       requiresAuth: false,

--- a/api/src/services/websocket.ts
+++ b/api/src/services/websocket.ts
@@ -6,7 +6,8 @@ const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 
 const CONNECTIONS_TABLE_NAME = process.env.CONNECTIONS_TABLE_NAME || '';
-const WEBSOCKET_API_URL = process.env.WEBSOCKET_API_URL || '';
+// CDK's webSocketApi.apiEndpoint returns wss:// — management API needs https://
+const WEBSOCKET_API_URL = (process.env.WEBSOCKET_API_URL || '').replace(/^wss:\/\//i, 'https://').replace(/^ws:\/\//i, 'http://');
 
 interface WebSocketMessage {
   type: string;

--- a/api/src/utils/pack-leaderboard.ts
+++ b/api/src/utils/pack-leaderboard.ts
@@ -6,6 +6,9 @@ import { assetS3UrlToCloudFrontUrl } from './s3';
 // Types
 // ---------------------------------------------------------------------------
 
+/** Pack IDs that have pack leaderboards enabled. */
+export const ELIGIBLE_PACK_IDS: number[] = [101, 102, 131, 346, 348];
+
 /** The difficulty slots we compute pack leaderboards for. */
 export const PACK_LEADERBOARD_DIFFICULTIES = ['medium', 'hard', 'challenge'] as const;
 export type PackLeaderboardDifficulty = (typeof PACK_LEADERBOARD_DIFFICULTIES)[number];
@@ -95,27 +98,63 @@ interface BestScoreRow {
  * For a given set of chart hashes and leaderboard IDs, fetch each user's single
  * best score per chart per leaderboard. "Best" is determined by the PlayLeaderboard
  * sortKey (DESC) which already encodes score + tie-break.
+ *
+ * Charts in cmodIneligibleHashes exclude plays where the player used CMOD
+ * (modifiers.speed.type = 'C').
  */
-async function getBestScoresForCharts(prisma: PrismaClient, chartHashes: string[], leaderboardIds: number[]): Promise<BestScoreRow[]> {
+async function getBestScoresForCharts(
+  prisma: PrismaClient,
+  chartHashes: string[],
+  leaderboardIds: number[],
+  cmodIneligibleHashes: Set<string>,
+): Promise<BestScoreRow[]> {
   if (chartHashes.length === 0) return [];
 
-  const rows: any[] = await prisma.$queryRaw`
-    SELECT DISTINCT ON (p."userId", p."chartHash", pl."leaderboardId")
-      p."userId"               AS "userId",
-      u.alias                  AS "userAlias",
-      u."profileImageUrl"      AS "userProfileImageUrl",
-      p."chartHash"            AS "chartHash",
-      pl."leaderboardId"       AS "leaderboardId",
-      (pl.data->>'score')::double precision AS score
-    FROM "PlayLeaderboard" pl
-    JOIN "Play" p  ON pl."playId" = p.id
-    JOIN "User" u  ON p."userId" = u.id
-    WHERE p."chartHash" = ANY(${chartHashes})
-      AND pl."leaderboardId" = ANY(${leaderboardIds})
-      AND u.banned = false
-      AND u."shadowBanned" = false
-    ORDER BY p."userId", p."chartHash", pl."leaderboardId", pl."sortKey" DESC
-  `;
+  const ineligibleArray = [...cmodIneligibleHashes];
+
+  let rows: any[];
+
+  if (ineligibleArray.length === 0) {
+    rows = await prisma.$queryRaw`
+      SELECT DISTINCT ON (p."userId", p."chartHash", pl."leaderboardId")
+        p."userId"               AS "userId",
+        u.alias                  AS "userAlias",
+        u."profileImageUrl"      AS "userProfileImageUrl",
+        p."chartHash"            AS "chartHash",
+        pl."leaderboardId"       AS "leaderboardId",
+        (pl.data->>'score')::double precision AS score
+      FROM "PlayLeaderboard" pl
+      JOIN "Play" p  ON pl."playId" = p.id
+      JOIN "User" u  ON p."userId" = u.id
+      WHERE p."chartHash" = ANY(${chartHashes})
+        AND pl."leaderboardId" = ANY(${leaderboardIds})
+        AND u.banned = false
+        AND u."shadowBanned" = false
+      ORDER BY p."userId", p."chartHash", pl."leaderboardId", pl."sortKey" DESC
+    `;
+  } else {
+    rows = await prisma.$queryRaw`
+      SELECT DISTINCT ON (p."userId", p."chartHash", pl."leaderboardId")
+        p."userId"               AS "userId",
+        u.alias                  AS "userAlias",
+        u."profileImageUrl"      AS "userProfileImageUrl",
+        p."chartHash"            AS "chartHash",
+        pl."leaderboardId"       AS "leaderboardId",
+        (pl.data->>'score')::double precision AS score
+      FROM "PlayLeaderboard" pl
+      JOIN "Play" p  ON pl."playId" = p.id
+      JOIN "User" u  ON p."userId" = u.id
+      WHERE p."chartHash" = ANY(${chartHashes})
+        AND pl."leaderboardId" = ANY(${leaderboardIds})
+        AND u.banned = false
+        AND u."shadowBanned" = false
+        AND (
+          NOT (p."chartHash" = ANY(${ineligibleArray}))
+          OR (p.modifiers->'speed'->>'type') IS DISTINCT FROM 'C'
+        )
+      ORDER BY p."userId", p."chartHash", pl."leaderboardId", pl."sortKey" DESC
+    `;
+  }
 
   return rows.map((r) => ({
     userId: r.userId,
@@ -155,6 +194,7 @@ export async function calculatePackLeaderboards(prisma: PrismaClient, packId: nu
     select: {
       chartHash: true,
       difficulty: true,
+      cmodIneligible: true,
     },
   });
 
@@ -163,6 +203,7 @@ export async function calculatePackLeaderboards(prisma: PrismaClient, packId: nu
   for (const d of PACK_LEADERBOARD_DIFFICULTIES) {
     hashesByDifficulty[d] = [];
   }
+  const cmodIneligibleHashes = new Set<string>();
   for (const sc of simfileCharts) {
     if (sc.difficulty && sc.difficulty in hashesByDifficulty) {
       // Avoid duplicates (a chart hash can appear in multiple simfiles within the pack)
@@ -170,14 +211,17 @@ export async function calculatePackLeaderboards(prisma: PrismaClient, packId: nu
         hashesByDifficulty[sc.difficulty].push(sc.chartHash);
       }
     }
+    if (sc.cmodIneligible) {
+      cmodIneligibleHashes.add(sc.chartHash);
+    }
   }
 
   // 3. Collect all unique chart hashes across all difficulties for one DB round-trip
   const allHashes = [...new Set(Object.values(hashesByDifficulty).flat())];
   const allLeaderboardIds = Object.values(SCORING_SYSTEMS) as number[];
 
-  // 4. Fetch best scores
-  const bestScores = await getBestScoresForCharts(prisma, allHashes, allLeaderboardIds);
+  // 4. Fetch best scores (CMOD plays excluded for flagged charts)
+  const bestScores = await getBestScoresForCharts(prisma, allHashes, allLeaderboardIds, cmodIneligibleHashes);
 
   // 5. Build the users dictionary and the leaderboard results
   const users: Record<string, { alias: string; profileImageUrl: string | null }> = {};

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,17 @@
 # Arrow Cloud Frontend
 
+## Environment / Build Setup
+
+Vite bakes `VITE_*` variables into the bundle at **build time**. Create a `.env.production` (gitignored) from `.env.example` before running `npm run build` for a production deployment:
+
+```
+VITE_API_BASE_URL=https://api.arrowcloud.dance
+VITE_SHARE_SERVICE_URL=https://share.arrowcloud.dance
+VITE_WEBSOCKET_URL=wss://<id>.execute-api.<region>.amazonaws.com/prod
+```
+
+The WebSocket URL comes from the `WebSocketApiUrl` CDK stack output (`ApiStack`). Without it, the streamer widget renders correctly but won't receive live score-refresh events.
+
 ## Localization
 
 We use `react-intl` for localization and Crowdin as a TMS.

--- a/frontend/src/pages/home/components/AboutCard.tsx
+++ b/frontend/src/pages/home/components/AboutCard.tsx
@@ -27,7 +27,7 @@ export const AboutCard: React.FC = () => {
             </p>
           </div>
 
-          <div className="pt-4">
+          <div className="pt-3">
             <div className="flex flex-wrap gap-4 justify-center">
               <Link
                 to="/register"

--- a/frontend/src/pages/profile/EditProfile.tsx
+++ b/frontend/src/pages/profile/EditProfile.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { User as UserIcon, Lock, Fingerprint, Key, Users, Camera, SlidersHorizontal, XCircle, Trophy } from 'lucide-react';
+import { User as UserIcon, Lock, Fingerprint, Key, Users, Camera, SlidersHorizontal, XCircle, Trophy, MonitorPlay } from 'lucide-react';
 import { updatePreferredLeaderboards, getUser } from '../../services/api';
 import { AppPageLayout } from '../../components';
 import {
@@ -71,26 +71,22 @@ const navigationItems: NavigationItem[] = [
       />
     ),
   },
-  // HIDDEN: Streamer Widget section temporarily disabled
-  // {
-  //   id: 'widget',
-  //   label: (
-  //     <span className="flex items-center gap-2">
-  //       <FormattedMessage defaultMessage="Streamer Widget" description="Navigation item label for streamer widget settings" id="34xrFN" />
-  //       <span className="badge badge-primary badge-xs">
-  //         <FormattedMessage defaultMessage="Beta" description="Badge label indicating a feature is in beta" id="NvFvI1" />
-  //       </span>
-  //     </span>
-  //   ),
-  //   icon: MonitorPlay,
-  //   description: (
-  //     <FormattedMessage
-  //       defaultMessage="Configure and preview your streaming widget"
-  //       description="Navigation item description for streamer widget settings"
-  //       id="ejPmny"
-  //     />
-  //   ),
-  // },
+  {
+    id: 'widget',
+    label: (
+      <span className="flex items-center gap-2">
+        <FormattedMessage defaultMessage="Streamer Widget" description="Navigation item label for streamer widget settings" id="34xrFN" />
+      </span>
+    ),
+    icon: MonitorPlay,
+    description: (
+      <FormattedMessage
+        defaultMessage="Configure and preview your streaming widget"
+        description="Navigation item description for streamer widget settings"
+        id="ejPmny"
+      />
+    ),
+  },
   {
     id: 'password',
     label: <FormattedMessage defaultMessage="Password" description="Navigation item label for password settings" id="EgWcdC" />,

--- a/frontend/src/pages/profile/components/WidgetSection.tsx
+++ b/frontend/src/pages/profile/components/WidgetSection.tsx
@@ -1,6 +1,18 @@
-import React, { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import React, { useState, useEffect, useRef } from 'react';
+import { useIntl } from 'react-intl';
 import { useAuth } from '../../../contexts/AuthContext';
+import { listPacks } from '../../../services/api';
+import type { PackListItem } from '../../../schemas/apiSchemas';
+import {
+  encodeWidgetConfig,
+  getWidgetDimensions,
+  ELIGIBLE_PACK_IDS,
+  type WidgetConfig,
+  type WidgetFeatureConfig,
+  type LeaderboardKey,
+  type PackLeaderboardDifficulty,
+} from '../../../utils/widgetConfig';
+import { ChevronUp, ChevronDown, X, Plus } from 'lucide-react';
 
 const AVAILABLE_THEMES = [
   { id: 'arrow-blue', label: 'Arrow Blue (Default)' },
@@ -25,300 +37,467 @@ const AVAILABLE_THEMES = [
   { id: 'bumblebee', label: 'Bumblebee' },
 ];
 
-const WIDGET_LEADERBOARDS = [
-  { id: 'HardEX', label: 'H.EX' },
-  { id: 'EX', label: 'EX' },
-  { id: 'ITG', label: 'ITG' },
-];
+const LB_LABELS: Record<LeaderboardKey, string> = { HardEX: 'H.EX', EX: 'EX', ITG: 'ITG' };
+const ALL_LB_KEYS: LeaderboardKey[] = ['HardEX', 'EX', 'ITG'];
+const DIFF_LABELS: Record<PackLeaderboardDifficulty, string> = { medium: 'Medium', hard: 'Hard', challenge: 'Challenge' };
 
-const WIDGET_FEATURES = [
-  { id: 'main', label: 'Main Information', description: 'Your rank and points', disabled: true },
-  { id: 'leaderboard', label: 'Overall Leaderboard', description: 'Show top players and rivals' },
-  { id: 'lastPlayed', label: 'Last Played', description: 'Show your most recent song' },
-];
+const LB_ID_MAP: Record<number, LeaderboardKey> = { 4: 'HardEX', 2: 'EX', 3: 'ITG' };
+
+function getDefaultLeaderboards(user: any): LeaderboardKey[] {
+  const prefs: number[] = user?.preferredLeaderboards ?? [];
+  const mapped = prefs.map((id: number) => LB_ID_MAP[id]).filter(Boolean) as LeaderboardKey[];
+  return mapped.length > 0 ? mapped : ['EX'];
+}
+
+function bestBannerUrl(pack: PackListItem): string | null {
+  return pack.mdBannerUrl ?? pack.bannerUrl ?? null;
+}
+
+function featureLabel(f: WidgetFeatureConfig): string {
+  if (f.type === 'profile') return 'Profile';
+  if (f.type === 'recentPlays') return 'Recent Plays';
+  if (f.type === 'packLeaderboard') return `Pack Leaderboard — ${f.packName || f.packId}`;
+  return 'Unknown';
+}
+
+// ---- Feature card sub-components ----
+
+const LeaderboardCheckboxes: React.FC<{
+  selected: LeaderboardKey[];
+  onChange: (keys: LeaderboardKey[]) => void;
+}> = ({ selected, onChange }) => (
+  <div className="flex gap-3 flex-wrap">
+    {ALL_LB_KEYS.map((key) => {
+      const checked = selected.includes(key);
+      return (
+        <label
+          key={key}
+          className={`flex items-center gap-1.5 cursor-pointer px-2 py-1 rounded border text-sm transition ${checked ? 'bg-primary text-primary-content border-primary' : 'border-base-300 hover:bg-base-200'}`}
+        >
+          <input
+            type="checkbox"
+            className="hidden"
+            checked={checked}
+            onChange={() => {
+              if (checked && selected.length === 1) return; // keep at least 1
+              onChange(checked ? selected.filter((k) => k !== key) : [...selected, key]);
+            }}
+          />
+          {LB_LABELS[key]}
+        </label>
+      );
+    })}
+  </div>
+);
+
+const PackLeaderboardConfig: React.FC<{
+  feature: Extract<WidgetFeatureConfig, { type: 'packLeaderboard' }>;
+  packs: PackListItem[];
+  onChange: (f: Extract<WidgetFeatureConfig, { type: 'packLeaderboard' }>) => void;
+}> = ({ feature, packs, onChange }) => {
+  const intl = useIntl();
+  return (
+    <div className="space-y-3 mt-2">
+      <div>
+        <label className="text-xs font-semibold text-base-content/70 mb-1 block">
+          {intl.formatMessage({ id: 'mFmFwY', defaultMessage: 'Pack', description: 'Pack select label in widget config' })}
+        </label>
+        <select
+          className="select select-sm select-bordered w-full"
+          value={feature.packId}
+          onChange={(e) => {
+            const pack = packs.find((p) => p.id === parseInt(e.target.value, 10));
+            if (pack) onChange({ ...feature, packId: pack.id, packName: pack.name, bannerUrl: bestBannerUrl(pack) });
+          }}
+        >
+          {packs.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="text-xs font-semibold text-base-content/70 mb-1 block">
+          {intl.formatMessage({ id: 'Ju1dPo', defaultMessage: 'Difficulty', description: 'Difficulty select label in widget config' })}
+        </label>
+        <div className="flex gap-2">
+          {(['medium', 'hard', 'challenge'] as PackLeaderboardDifficulty[]).map((d) => (
+            <button
+              key={d}
+              type="button"
+              className={`btn btn-xs ${feature.difficulty === d ? 'btn-primary' : 'btn-outline'}`}
+              onClick={() => onChange({ ...feature, difficulty: d })}
+            >
+              {DIFF_LABELS[d]}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div>
+        <label className="text-xs font-semibold text-base-content/70 mb-1 block">
+          {intl.formatMessage({ id: 'RCi2iU', defaultMessage: 'Scoring Systems', description: 'Scoring systems label in widget pack leaderboard config' })}
+        </label>
+        <LeaderboardCheckboxes selected={feature.leaderboards} onChange={(keys) => onChange({ ...feature, leaderboards: keys })} />
+      </div>
+    </div>
+  );
+};
+
+const RecentPlaysConfig: React.FC<{
+  feature: Extract<WidgetFeatureConfig, { type: 'recentPlays' }>;
+  onChange: (f: Extract<WidgetFeatureConfig, { type: 'recentPlays' }>) => void;
+}> = ({ feature, onChange }) => {
+  const intl = useIntl();
+  return (
+    <div className="mt-2">
+      <label className="text-xs font-semibold text-base-content/70 mb-1 block">
+        {intl.formatMessage({ id: 'r8saR8', defaultMessage: 'Scoring Systems', description: 'Scoring systems label in widget recent plays config' })}
+      </label>
+      <LeaderboardCheckboxes selected={feature.leaderboards} onChange={(keys) => onChange({ ...feature, leaderboards: keys })} />
+    </div>
+  );
+};
+
+interface FeatureCardProps {
+  feature: WidgetFeatureConfig;
+  index: number;
+  total: number;
+  packs: PackListItem[];
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+  onChange: (f: WidgetFeatureConfig) => void;
+}
+
+const FeatureCard: React.FC<FeatureCardProps> = ({ feature, index, total, packs, onMoveUp, onMoveDown, onRemove, onChange }) => {
+  const intl = useIntl();
+  const hasConfig = feature.type !== 'profile';
+  const [expanded, setExpanded] = useState(hasConfig);
+
+  return (
+    <div className="border border-base-300/50 rounded-lg bg-base-200/40">
+      <div className="flex items-center gap-2 p-3">
+        <button type="button" className="flex-1 text-left text-sm font-medium" onClick={() => hasConfig && setExpanded((e) => !e)}>
+          <span className="text-base-content/50 mr-2 text-xs">
+            {intl.formatMessage({ id: 'uj5W+N', defaultMessage: '#{rank}', description: 'Feature position indicator' }, { rank: index + 1 })}
+          </span>
+          {featureLabel(feature)}
+          {hasConfig && (
+            <span className="ml-2 text-xs text-base-content/40">
+              {expanded ? <ChevronUp className="w-3 h-3 inline" /> : <ChevronDown className="w-3 h-3 inline" />}
+            </span>
+          )}
+        </button>
+        <div className="flex items-center gap-1">
+          <button type="button" className="btn btn-ghost btn-xs" onClick={onMoveUp} disabled={index === 0}>
+            <ChevronUp className="w-3 h-3" />
+          </button>
+          <button type="button" className="btn btn-ghost btn-xs" onClick={onMoveDown} disabled={index === total - 1}>
+            <ChevronDown className="w-3 h-3" />
+          </button>
+          <button type="button" className="btn btn-ghost btn-xs text-error" onClick={onRemove}>
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+      {expanded && hasConfig && (
+        <div className="px-3 pb-3 border-t border-base-300/30 pt-2">
+          {feature.type === 'recentPlays' && <RecentPlaysConfig feature={feature} onChange={(f) => onChange(f)} />}
+          {feature.type === 'packLeaderboard' && <PackLeaderboardConfig feature={feature} packs={packs} onChange={(f) => onChange(f)} />}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---- Main wizard component ----
 
 export const WidgetSection: React.FC = () => {
   const { user } = useAuth();
+  const intl = useIntl();
   const [selectedTheme, setSelectedTheme] = useState('arrow-blue');
-  const [selectedLeaderboards, setSelectedLeaderboards] = useState<string[]>(['HardEX', 'EX', 'ITG']);
-  const [selectedFeatures, setSelectedFeatures] = useState<string[]>(['main', 'leaderboard', 'lastPlayed']);
-  const [rotationDelay, setRotationDelay] = useState(30);
   const [compatMode, setCompatMode] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [showAddMenu, setShowAddMenu] = useState(false);
+  const addMenuRef = useRef<HTMLDivElement>(null);
 
-  const toggleLeaderboard = (id: string) => {
-    setSelectedLeaderboards((prev) => {
-      if (prev.includes(id)) {
-        // Don't allow deselecting the last leaderboard
-        if (prev.length === 1) return prev;
-        return prev.filter((lb) => lb !== id);
+  const [features, setFeatures] = useState<WidgetFeatureConfig[]>([{ type: 'profile' }]);
+  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>('horizontal');
+  const [packs, setPacks] = useState<PackListItem[]>([]);
+
+  // Close add menu on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
+        setShowAddMenu(false);
       }
-      return [...prev, id];
-    });
-  };
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
 
-  const toggleFeature = (id: string) => {
-    setSelectedFeatures((prev) => {
-      if (prev.includes(id)) {
-        return prev.filter((f) => f !== id);
-      }
-      return [...prev, id];
-    });
-  };
+  // Load eligible packs once, filtering to known eligible IDs client-side as a safety net
+  useEffect(() => {
+    listPacks({ eligibleOnly: true, limit: 100 })
+      .then((res) => setPacks(res.data.filter((p) => ELIGIBLE_PACK_IDS.includes(p.id))))
+      .catch(() => {});
+  }, []);
 
-  // Build widget URL with all parameters
+  const config: WidgetConfig = { version: 1, orientation, features };
+  const encodedConfig = encodeWidgetConfig(config);
+  const { width: widgetWidth, height: widgetHeight } = getWidgetDimensions(config);
+
   const params = new URLSearchParams();
-  if (user?.id) {
-    params.set('userId', user.id.toString());
-  }
-  if (!compatMode) {
-    params.set('theme', selectedTheme);
-  }
-  if (selectedLeaderboards.length > 0) {
-    params.set('leaderboards', selectedLeaderboards.join(','));
-  }
-  params.set('delay', rotationDelay.toString());
-  params.set('features', selectedFeatures.join(','));
-  if (compatMode) {
-    params.set('compat', 'true');
-  }
+  if (user?.id) params.set('userId', user.id.toString());
+  if (!compatMode) params.set('theme', selectedTheme);
+  params.set('config', encodedConfig);
+  if (compatMode) params.set('compat', 'true');
   const widgetUrl = `${window.location.origin}/widget/streamer?${params.toString()}`;
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+  const hasProfile = features.some((f) => f.type === 'profile');
+  const hasRecentPlays = features.some((f) => f.type === 'recentPlays');
+  const featureCount = features.length;
+
+  const moveUp = (i: number) => {
+    if (i === 0) return;
+    const next = [...features];
+    [next[i - 1], next[i]] = [next[i], next[i - 1]];
+    setFeatures(next);
+  };
+
+  const moveDown = (i: number) => {
+    if (i === featureCount - 1) return;
+    const next = [...features];
+    [next[i], next[i + 1]] = [next[i + 1], next[i]];
+    setFeatures(next);
+  };
+
+  const removeFeature = (i: number) => {
+    setFeatures(features.filter((_, idx) => idx !== i));
+  };
+
+  const updateFeature = (i: number, f: WidgetFeatureConfig) => {
+    const next = [...features];
+    next[i] = f;
+    setFeatures(next);
+  };
+
+  const addFeature = (f: WidgetFeatureConfig) => {
+    if (featureCount >= 5) return;
+    setFeatures([...features, f]);
+    setShowAddMenu(false);
+  };
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(widgetUrl);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
-  // Calculate widget dimensions based on selected features
-  const baseWidth = 260;
-  const leaderboardWidth = selectedFeatures.includes('leaderboard') ? 260 : 0;
-  const lastPlayedWidth = selectedFeatures.includes('lastPlayed') ? 240 : 0;
-  const widgetWidth = baseWidth + leaderboardWidth + lastPlayedWidth;
-  const widgetHeight = 300;
+  const defaultPack = packs[0];
 
   return (
     <div className="space-y-6">
-      {/* Compatibility Mode */}
-      <div>
-        <label className="label cursor-pointer justify-start gap-3">
-          <input type="checkbox" className="checkbox checkbox-primary" checked={compatMode} onChange={(e) => setCompatMode(e.target.checked)} />
+      {/* Global Settings */}
+      <div className="space-y-4">
+        <div className="flex gap-3 flex-wrap items-end">
+          {/* Orientation */}
           <div>
-            <span className="label-text font-semibold">
-              <FormattedMessage defaultMessage="Compatibility Mode" description="Label for compatibility mode checkbox" id="THr3aV" />
-            </span>
-            <div className="text-sm text-base-content/60">
-              <FormattedMessage
-                defaultMessage="Use fallback colors for older OBS versions (disables theme selection)"
-                description="Helper text for compatibility mode"
-                id="A5yRgM"
-              />
+            <label className="label py-0 mb-1">
+              <span className="label-text font-semibold text-sm">
+                {intl.formatMessage({ id: 'Jhvn5z', defaultMessage: 'Orientation', description: 'Widget orientation label' })}
+              </span>
+            </label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className={`btn btn-sm ${orientation === 'horizontal' ? 'btn-primary' : 'btn-outline'}`}
+                onClick={() => setOrientation('horizontal')}
+              >
+                {intl.formatMessage({ id: 'EXu3i+', defaultMessage: 'Horizontal', description: 'Horizontal orientation option' })}
+              </button>
+              <button
+                type="button"
+                className={`btn btn-sm ${orientation === 'vertical' ? 'btn-primary' : 'btn-outline'}`}
+                onClick={() => setOrientation('vertical')}
+              >
+                {intl.formatMessage({ id: 'TTN+1v', defaultMessage: 'Vertical', description: 'Vertical orientation option' })}
+              </button>
             </div>
           </div>
-        </label>
-      </div>
 
-      {/* Theme Selector */}
-      <div>
-        <label className="label">
-          <span className="label-text font-semibold">
-            <FormattedMessage defaultMessage="Widget Theme" description="Label for widget theme selector" id="dDM60o" />
-          </span>
-        </label>
-        <div className="flex gap-4">
-          <select
-            className="select select-bordered w-full max-w-xs"
-            value={selectedTheme}
-            onChange={(e) => setSelectedTheme(e.target.value)}
-            disabled={compatMode}
-          >
-            {AVAILABLE_THEMES.map((theme) => (
-              <option key={theme.id} value={theme.id}>
-                {theme.label}
-              </option>
-            ))}
-          </select>
+          {/* Theme */}
+          <div className="flex-1 min-w-[160px]">
+            <label className="label py-0 mb-1">
+              <span className="label-text font-semibold text-sm">
+                {intl.formatMessage({ id: '7Ha4j8', defaultMessage: 'Theme', description: 'Widget theme label' })}
+              </span>
+            </label>
+            <select
+              className="select select-bordered select-sm w-full"
+              value={selectedTheme}
+              onChange={(e) => setSelectedTheme(e.target.value)}
+              disabled={compatMode}
+            >
+              {AVAILABLE_THEMES.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Compat */}
+          <div>
+            <label className="label cursor-pointer justify-start gap-2 py-0">
+              <input type="checkbox" className="checkbox checkbox-sm checkbox-primary" checked={compatMode} onChange={(e) => setCompatMode(e.target.checked)} />
+              <span className="label-text text-sm">
+                {intl.formatMessage({ id: 'Qa4UgA', defaultMessage: 'Compatibility Mode', description: 'Compat mode checkbox label' })}
+              </span>
+            </label>
+            <div className="text-xs text-base-content/50 ml-6">
+              {intl.formatMessage({ id: '1JZBtk', defaultMessage: 'For OBS older than v31', description: 'Compat mode hint text' })}
+            </div>
+          </div>
         </div>
       </div>
 
-      {/* Widget Features */}
+      {/* Features */}
       <div>
-        <label className="label">
+        <label className="label py-0 mb-2">
           <span className="label-text font-semibold">
-            <FormattedMessage defaultMessage="Widget Features" description="Label for widget features selection" id="ZlE4+d" />
+            {intl.formatMessage({ id: 'z5zM6j', defaultMessage: 'Features', description: 'Features section label' })}
           </span>
         </label>
         <div className="space-y-2">
-          {WIDGET_FEATURES.map((feature) => (
-            <label
-              key={feature.id}
-              className={`flex items-start gap-3 p-3 rounded-lg border transition ${feature.disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-base-200'}`}
-            >
-              <input
-                type="checkbox"
-                className="checkbox checkbox-primary mt-0.5"
-                checked={selectedFeatures.includes(feature.id)}
-                onChange={() => !feature.disabled && toggleFeature(feature.id)}
-                disabled={feature.disabled}
-              />
-              <div className="flex-1">
-                <div className="font-medium">{feature.label}</div>
-                <div className="text-sm text-base-content/60">{feature.description}</div>
+          {features.map((f, i) => (
+            <FeatureCard
+              key={i}
+              feature={f}
+              index={i}
+              total={featureCount}
+              packs={packs}
+              onMoveUp={() => moveUp(i)}
+              onMoveDown={() => moveDown(i)}
+              onRemove={() => removeFeature(i)}
+              onChange={(updated) => updateFeature(i, updated)}
+            />
+          ))}
+        </div>
+
+        {/* Add Feature */}
+        {featureCount < 5 && (
+          <div className="relative mt-2" ref={addMenuRef}>
+            <button type="button" className="btn btn-sm btn-outline gap-1" onClick={() => setShowAddMenu((v) => !v)}>
+              <Plus className="w-3.5 h-3.5" />
+              {intl.formatMessage({ id: 'jPoSOu', defaultMessage: 'Add Feature', description: 'Add feature button label' })}
+            </button>
+            {showAddMenu && (
+              <div className="absolute top-full left-0 mt-1 bg-base-100 border border-base-300 rounded-lg shadow-xl z-10 min-w-[220px] py-1">
+                <button
+                  type="button"
+                  className={`w-full text-left px-4 py-2 text-sm hover:bg-base-200 transition ${hasProfile ? 'opacity-40 cursor-not-allowed' : ''}`}
+                  onClick={() => !hasProfile && addFeature({ type: 'profile' })}
+                >
+                  {intl.formatMessage({ id: 'ndGG1t', defaultMessage: 'Profile', description: 'Profile feature name in add menu' })}
+                  {hasProfile && (
+                    <span className="ml-2 text-xs text-base-content/50">
+                      {intl.formatMessage({ id: 'pT7MXb', defaultMessage: 'already added', description: 'Already added indicator in feature menu' })}
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className={`w-full text-left px-4 py-2 text-sm hover:bg-base-200 transition ${hasRecentPlays ? 'opacity-40 cursor-not-allowed' : ''}`}
+                  onClick={() => !hasRecentPlays && addFeature({ type: 'recentPlays', leaderboards: getDefaultLeaderboards(user) })}
+                >
+                  {intl.formatMessage({ id: '/PBHyq', defaultMessage: 'Recent Plays', description: 'Recent plays feature name in add menu' })}
+                  {hasRecentPlays && (
+                    <span className="ml-2 text-xs text-base-content/50">
+                      {intl.formatMessage({ id: 'pT7MXb', defaultMessage: 'already added', description: 'Already added indicator in feature menu' })}
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  className={`w-full text-left px-4 py-2 text-sm hover:bg-base-200 transition ${!defaultPack ? 'opacity-40 cursor-not-allowed' : ''}`}
+                  onClick={() =>
+                    defaultPack &&
+                    addFeature({
+                      type: 'packLeaderboard',
+                      packId: defaultPack.id,
+                      packName: defaultPack.name,
+                      bannerUrl: bestBannerUrl(defaultPack),
+                      difficulty: 'challenge',
+                      leaderboards: getDefaultLeaderboards(user),
+                    })
+                  }
+                >
+                  {intl.formatMessage({ id: 'B6ktnP', defaultMessage: 'Pack Leaderboard', description: 'Pack leaderboard feature name in add menu' })}
+                  {!defaultPack && (
+                    <span className="ml-2 text-xs text-base-content/50">
+                      {intl.formatMessage({ id: 'VlCXVh', defaultMessage: 'no packs available', description: 'No packs available indicator' })}
+                    </span>
+                  )}
+                </button>
               </div>
-            </label>
-          ))}
-        </div>
-        <label className="label">
-          <span className="label-text-alt text-base-content/60">
-            <FormattedMessage defaultMessage="Choose what information to display in the widget" description="Helper text for feature selection" id="C9Lob8" />
-          </span>
-        </label>
+            )}
+          </div>
+        )}
+        {featureCount >= 5 && (
+          <p className="text-xs text-base-content/50 mt-2">
+            {intl.formatMessage({ id: 'TL6lMm', defaultMessage: 'Maximum of 5 features reached.', description: 'Max features reached message' })}
+          </p>
+        )}
       </div>
 
-      {/* Leaderboard Selection */}
+      {/* Preview */}
       <div>
-        <label className="label">
+        <label className="label py-0 mb-2">
           <span className="label-text font-semibold">
-            <FormattedMessage defaultMessage="Leaderboards to Show" description="Label for leaderboard selection" id="dPQaz6" />
+            {intl.formatMessage({ id: 'Lh3mLz', defaultMessage: 'Preview', description: 'Preview section label' })}
           </span>
         </label>
-        <div className="flex gap-4">
-          {WIDGET_LEADERBOARDS.map((lb) => (
-            <label key={lb.id} className="label cursor-pointer gap-2">
-              <input
-                type="checkbox"
-                className="checkbox checkbox-primary"
-                checked={selectedLeaderboards.includes(lb.id)}
-                onChange={() => toggleLeaderboard(lb.id)}
-                disabled={selectedLeaderboards.length === 1 && selectedLeaderboards.includes(lb.id)}
-              />
-              <span className="label-text">{lb.label}</span>
-            </label>
-          ))}
-        </div>
-        <label className="label">
-          <span className="label-text-alt text-base-content/60">
-            <FormattedMessage
-              defaultMessage="Select which leaderboards to cycle through (at least one required)"
-              description="Helper text for leaderboard selection"
-              id="CcMJR2"
-            />
-          </span>
-        </label>
-      </div>
-
-      {/* Rotation Delay */}
-      <div>
-        <label className="label">
-          <span className="label-text font-semibold">
-            <FormattedMessage defaultMessage="Rotation Delay" description="Label for rotation delay slider" id="MZJzFb" />
-          </span>
-        </label>
-        <div className="flex items-center gap-4">
-          <input
-            type="range"
-            min="10"
-            max="120"
-            value={rotationDelay}
-            onChange={(e) => setRotationDelay(Number(e.target.value))}
-            className="range range-primary flex-1"
-            step="5"
-          />
-          <span className="text-sm font-mono w-16 text-right">{rotationDelay}</span>
-        </div>
-        <label className="label">
-          <span className="label-text-alt text-base-content/60">
-            <FormattedMessage
-              defaultMessage="How long to show each leaderboard before switching (10-120 seconds)"
-              description="Helper text for rotation delay"
-              id="di9f3h"
-            />
-          </span>
-        </label>
-      </div>
-
-      {/* Widget Preview */}
-      <div>
-        <label className="label">
-          <span className="label-text font-semibold">
-            <FormattedMessage defaultMessage="Preview" description="Label for widget preview section" id="eRpp8o" />
-          </span>
-        </label>
-        <div className="bg-base-200 rounded-lg p-4 flex items-center justify-center overflow-x-auto">
+        <div className="bg-base-200 rounded-lg p-4 flex items-center justify-center overflow-auto">
           <iframe src={widgetUrl} width={widgetWidth} height={widgetHeight} className="border-0 rounded shadow-xl" style={{ backgroundColor: 'transparent' }} />
         </div>
-        <label className="label">
-          <span className="label-text-alt text-base-content/60">
-            <FormattedMessage
-              defaultMessage="Widget dimensions: {width}×{height}px"
-              description="Shows widget dimensions"
-              id="X2YpwH"
-              values={{ width: widgetWidth, height: widgetHeight }}
-            />
-          </span>
-        </label>
       </div>
 
-      {/* Widget URL */}
-      <div>
-        <label className="label">
-          <span className="label-text font-semibold">
-            <FormattedMessage defaultMessage="Widget URL" description="Label for widget URL" id="2d72YH" />
-          </span>
-        </label>
-        <div className="flex gap-2">
-          <input type="text" value={widgetUrl} readOnly className="input input-bordered flex-1 font-mono text-sm" />
-          <button className="btn btn-primary" onClick={() => copyToClipboard(widgetUrl)}>
-            {copied ? (
-              <FormattedMessage defaultMessage="Copied!" description="Button text after copying" id="aS/YuY" />
-            ) : (
-              <FormattedMessage defaultMessage="Copy URL" description="Button text to copy URL" id="BAchyT" />
-            )}
-          </button>
-        </div>
-        <label className="label">
-          <span className="label-text-alt text-base-content/60">
-            <FormattedMessage defaultMessage="Use this URL in OBS as a Browser Source" description="Helper text for widget URL" id="ebpbUs" />
-          </span>
-        </label>
-      </div>
-
-      {/* Instructions */}
+      {/* OBS Setup */}
       <div className="alert alert-info">
-        <div className="flex flex-col gap-2 text-sm">
-          <div className="font-semibold">
-            <FormattedMessage defaultMessage="How to use in OBS:" description="Instructions heading" id="Dya6QR" />
+        <div className="flex flex-col gap-2 text-sm w-full">
+          <div className="font-semibold">{intl.formatMessage({ id: '0a8qQn', defaultMessage: 'OBS Setup', description: 'OBS setup section heading' })}</div>
+          {!compatMode && (
+            <div className="text-warning font-medium">
+              {intl.formatMessage({ id: 'pilwMh', defaultMessage: 'OBS Studio v31 or higher required for themes.', description: 'OBS version warning' })}
+            </div>
+          )}
+          <div className="flex flex-col gap-1 text-base-content/80">
+            <div>{intl.formatMessage({ id: 'xHjitK', defaultMessage: '1. Add a Browser Source in OBS', description: 'OBS setup step 1' })}</div>
+            <div>{intl.formatMessage({ id: 'FBSgTm', defaultMessage: '2. Paste the URL below', description: 'OBS setup step 2' })}</div>
+            <div>
+              {intl.formatMessage(
+                { id: 'a9j6HF', defaultMessage: '3. Set Width: {width}px, Height: {height}px', description: 'OBS setup step 3 with dimensions' },
+                { width: widgetWidth, height: widgetHeight },
+              )}
+            </div>
+            <div>
+              {intl.formatMessage({
+                id: 'D06P28',
+                defaultMessage: '4. Enable "Shutdown source when not visible" and "Refresh browser when scene becomes active"',
+                description: 'OBS setup step 4',
+              })}
+            </div>
           </div>
-          <div className="text-warning font-medium mb-1">
-            <FormattedMessage
-              defaultMessage="Note: OBS Studio version 31 or higher is required for proper display."
-              description="OBS version requirement warning"
-              id="71hxBe"
-            />
+          <div className="flex gap-2 mt-1">
+            <input type="text" value={widgetUrl} readOnly className="input input-sm input-bordered flex-1 font-mono text-xs" />
+            <button className="btn btn-sm btn-primary" onClick={copyToClipboard}>
+              {copied
+                ? intl.formatMessage({ id: 'EDgCxn', defaultMessage: 'Copied!', description: 'URL copied confirmation' })
+                : intl.formatMessage({ id: 'DsKB1w', defaultMessage: 'Copy URL', description: 'Copy URL button label' })}
+            </button>
           </div>
-          <ol className="list-decimal list-inside space-y-1 text-base-content/80">
-            <li>
-              <FormattedMessage defaultMessage="Add a new Browser Source in OBS" description="OBS instruction step 1" id="mFXNP+" />
-            </li>
-            <li>
-              <FormattedMessage defaultMessage="Paste the Widget URL above" description="OBS instruction step 2" id="ibF5yl" />
-            </li>
-            <li>
-              <FormattedMessage
-                defaultMessage="Set Width: {width}, Height: {height}"
-                description="OBS instruction step 3"
-                id="SsRETH"
-                values={{ width: widgetWidth, height: widgetHeight }}
-              />
-            </li>
-            <li>
-              <FormattedMessage
-                defaultMessage="Check 'Shutdown source when not visible' and 'Refresh browser when scene becomes active'"
-                description="OBS instruction step 4"
-                id="QYJaeC"
-              />
-            </li>
-          </ol>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/widget/StreamerWidgetPage.tsx
+++ b/frontend/src/pages/widget/StreamerWidgetPage.tsx
@@ -1,173 +1,68 @@
 import React, { useState, useEffect } from 'react';
-import { ProfileAvatar, GradeImage } from '../../components';
-import { BannerImage } from '../../components/ui/BannerImage';
-import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
-import { Swords } from 'lucide-react';
-import { motion } from 'framer-motion';
 import { useSearchParams } from 'react-router-dom';
 import { getWidgetData } from '../../services/api';
 import type { WidgetDataResponse } from '../../schemas/apiSchemas';
 import { useWebSocket } from '../../hooks/useWebSocket';
+import { decodeWidgetConfig, getWidgetDimensions, type WidgetConfig } from '../../utils/widgetConfig';
+import { ProfileStatsPanel } from './panels/ProfileStatsPanel';
+import { RecentPlaysPanel } from './panels/RecentPlaysPanel';
+import { PackLeaderboardPanel } from './panels/PackLeaderboardPanel';
 
-interface UserStats {
-  rank: number;
-  totalPoints: number;
-  chartsPlayed: number;
-  totalParticipants: number;
-}
-
-interface LeaderboardEntry {
-  rank: number;
-  alias: string;
-  points: number;
-  profileImageUrl: string | null;
-  isSelf?: boolean;
-  isRival?: boolean;
-}
-
-interface LeaderboardData {
-  stats: UserStats;
-  entries: LeaderboardEntry[];
-}
-
-type LeaderboardMode = 'HardEX' | 'EX' | 'ITG';
+const WIDGET_KEYFRAMES = `@keyframes widgetFadeIn { from { opacity: 0 } to { opacity: 1 } }`;
 
 export const StreamerWidgetPage: React.FC = () => {
-  const { formatNumber, formatMessage } = useIntl();
   const [searchParams] = useSearchParams();
-  const [scrollIndex, setScrollIndex] = useState(0);
-  const [scrollDirection, setScrollDirection] = useState<'down' | 'up'>('down');
   const [widgetData, setWidgetData] = useState<WidgetDataResponse | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Get parameters from URL
   const userIdParam = searchParams.get('userId');
   const themeParam = searchParams.get('theme');
-  const leaderboardsParam = searchParams.get('leaderboards');
-  const delayParam = searchParams.get('delay');
-  const featuresParam = searchParams.get('features');
+  const configParam = searchParams.get('config');
   const compatMode = searchParams.get('compat') === 'true';
 
-  // Parse features from comma-separated string
-  const enabledFeatures = featuresParam ? featuresParam.split(',') : ['main', 'leaderboard', 'lastPlayed'];
-  const showLeaderboard = enabledFeatures.includes('leaderboard');
-  const showLastPlayed = enabledFeatures.includes('lastPlayed');
+  const config: WidgetConfig | null = configParam ? decodeWidgetConfig(configParam) : null;
+  const { width: totalWidth, height: totalHeight } = config ? getWidgetDimensions(config) : { width: 235, height: 300 };
 
-  // Calculate dynamic width based on enabled features
-  const baseWidth = 235; // Main info section
-  const leaderboardWidth = showLeaderboard ? 290 : 0;
-  const lastPlayedWidth = showLastPlayed ? 235 : 0;
-  const totalWidth = baseWidth + leaderboardWidth + lastPlayedWidth;
-
-  // Parse leaderboards from comma-separated string, default to all three
-  const availableLeaderboards: LeaderboardMode[] = leaderboardsParam
-    ? (leaderboardsParam.split(',').filter((lb) => ['HardEX', 'EX', 'ITG'].includes(lb)) as LeaderboardMode[])
-    : ['HardEX', 'EX', 'ITG'];
-
-  // Parse rotation delay (in seconds), default to 30s, clamp between 10-120
-  const rotationDelay = Math.max(10, Math.min(120, Number(delayParam) || 30)) * 1000; // Convert to ms
-
-  const [currentLeaderboardIndex, setCurrentLeaderboardIndex] = useState(0);
-  const leaderboard = availableLeaderboards[currentLeaderboardIndex];
-
-  // WebSocket connection for real-time updates
   const WS_URL = (import.meta as any).env?.VITE_WEBSOCKET_URL || '';
-  const {
-    isConnected: wsConnected,
-    lastMessage,
-    error: wsError,
-  } = useWebSocket({
+  const { isConnected: wsConnected, lastMessage } = useWebSocket({
     url: WS_URL,
     userId: userIdParam || undefined,
-    autoConnect: true,
+    autoConnect: !!WS_URL,
   });
 
-  // Log WebSocket state changes
+  const fetchData = async () => {
+    if (!userIdParam) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const data = await getWidgetData(userIdParam, configParam || undefined);
+      setWidgetData(data);
+    } catch (error) {
+      console.error('Failed to fetch widget data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    console.log('[Widget] WebSocket connection state:', {
-      isConnected: wsConnected,
-      url: WS_URL,
-      hasError: !!wsError,
-    });
-  }, [wsConnected, wsError, WS_URL]);
-
-  // Fetch widget data on mount
-  useEffect(() => {
-    const fetchData = async () => {
-      if (!userIdParam) {
-        setLoading(false);
-        return;
-      }
-
-      try {
-        const data = await getWidgetData(userIdParam, featuresParam || undefined);
-        setWidgetData(data);
-      } catch (error) {
-        console.error('Failed to fetch widget data:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchData();
-  }, [userIdParam, featuresParam]);
+  }, [userIdParam, configParam]);
 
-  // Handle WebSocket messages and refresh data
   useEffect(() => {
     if (!lastMessage || !userIdParam) return;
-
-    console.log('[Widget] WebSocket message received:', lastMessage);
-
-    // Handle refresh notifications
     if (lastMessage.type === 'refresh' || lastMessage.type === 'widgetUpdate') {
-      // Check if this message is for our userId
-      const messageUserId = lastMessage.userId;
+      const messageUserId = (lastMessage as any).userId ?? (lastMessage as any).data?.userId;
       if (!messageUserId || messageUserId === userIdParam) {
-        console.log('[Widget] Refresh triggered by WebSocket message');
-
-        // Refresh widget data
-        getWidgetData(userIdParam, featuresParam || undefined)
-          .then((data) => {
-            setWidgetData(data);
-            console.log('[Widget] Data refreshed successfully');
-          })
-          .catch((error) => {
-            console.error('[Widget] Failed to refresh data:', error);
-          });
+        getWidgetData(userIdParam, configParam || undefined)
+          .then((data) => setWidgetData(data))
+          .catch((error) => console.error('[Widget] Failed to refresh data:', error));
       }
     }
-  }, [lastMessage, userIdParam, featuresParam]);
+  }, [lastMessage, userIdParam, configParam]);
 
-  // Get data for current leaderboard
-  const currentData: LeaderboardData | null = widgetData?.leaderboards?.[leaderboard] || null;
-  const stats = currentData?.stats;
-
-  // Map API entries to component format
-  const leaderboardWithUser =
-    currentData?.entries.map((entry) => ({
-      rank: entry.rank,
-      alias: entry.alias,
-      points: entry.points,
-      profileImageUrl: entry.profileImageUrl,
-      isSelf: entry.isSelf,
-      isRival: entry.isRival,
-    })) || [];
-
-  // Calculate how many entries fit in the visible area (approximately 5 entries)
-  const visibleEntries = 5;
-  const maxScrollIndex = Math.max(0, leaderboardWithUser.length - visibleEntries);
-
-  // Reset scroll when leaderboard changes
-  useEffect(() => {
-    setScrollIndex(0);
-    setScrollDirection('down');
-  }, [leaderboard]);
-
-  // Apply theme from query parameter
   useEffect(() => {
     if (compatMode) {
-      // Compatibility mode: use hardcoded fallback colors (no OKLCH)
-      // Override all color-related CSS variables with hex values
       const style = document.createElement('style');
       style.id = 'compat-mode-colors';
       style.textContent = `
@@ -183,8 +78,6 @@ export const StreamerWidgetPage: React.FC = () => {
           --success: 16 185 129 !important;
           --error: 239 68 68 !important;
         }
-        
-        /* Override any Tailwind color utilities to use RGB */
         .bg-primary { background-color: rgb(59 130 246) !important; }
         .text-primary { color: rgb(59 130 246) !important; }
         .bg-accent { background-color: rgb(245 158 11) !important; }
@@ -194,8 +87,6 @@ export const StreamerWidgetPage: React.FC = () => {
         .bg-base-300 { background-color: rgb(15 23 42) !important; }
         .text-base-content { color: rgb(229 231 235) !important; }
         .border-base-content { border-color: rgb(229 231 235) !important; }
-        
-        /* Opacity variants */
         .bg-primary\\/5 { background-color: rgba(59, 130, 246, 0.05) !important; }
         .bg-primary\\/10 { background-color: rgba(59, 130, 246, 0.1) !important; }
         .bg-primary\\/20 { background-color: rgba(59, 130, 246, 0.2) !important; }
@@ -204,405 +95,88 @@ export const StreamerWidgetPage: React.FC = () => {
         .bg-accent\\/20 { background-color: rgba(245, 158, 11, 0.2) !important; }
         .bg-base-200\\/50 { background-color: rgba(17, 24, 39, 0.5) !important; }
         .bg-base-300\\/30 { background-color: rgba(15, 23, 42, 0.3) !important; }
-        .text-base-content\\/40 { color: rgba(229, 231, 235, 0.4) !important; }
-        .text-base-content\\/50 { color: rgba(229, 231, 235, 0.5) !important; }
         .text-base-content\\/60 { color: rgba(229, 231, 235, 0.6) !important; }
-        .text-base-content\\/70 { color: rgba(229, 231, 235, 0.7) !important; }
-        .text-base-content\\/80 { color: rgba(229, 231, 235, 0.8) !important; }
+        .text-base-content\\/70 { color: rgba(229, 231, 235, 0.9) !important; }
         .border-base-content\\/10 { border-color: rgba(229, 231, 235, 0.1) !important; }
         .border-primary\\/40 { border-color: rgba(59, 130, 246, 0.4) !important; }
-        .border-accent\\/30 { border-color: rgba(245, 158, 11, 0.3) !important; }
-        
-        /* Gradients */
         .from-base-200 { --tw-gradient-from: rgb(17 24 39) !important; }
         .via-base-300 { --tw-gradient-via: rgb(15 23 42) !important; }
         .to-base-200 { --tw-gradient-to: rgb(17 24 39) !important; }
         .from-primary\\/5 { --tw-gradient-from: rgba(59, 130, 246, 0.05) !important; }
         .to-accent\\/5 { --tw-gradient-to: rgba(245, 158, 11, 0.05) !important; }
-        .via-primary\\/50 { --tw-gradient-via: rgba(59, 130, 246, 0.5) !important; }
-        .via-accent\\/50 { --tw-gradient-via: rgba(245, 158, 11, 0.5) !important; }
-        
-        /* Shadows */
-        .shadow-primary\\/20 { --tw-shadow-color: rgba(59, 130, 246, 0.2) !important; }
-        .shadow-primary\\/50 { --tw-shadow-color: rgba(59, 130, 246, 0.5) !important; }
-        .shadow-accent\\/10 { --tw-shadow-color: rgba(245, 158, 11, 0.1) !important; }
         .shadow-success\\/50 { --tw-shadow-color: rgba(16, 185, 129, 0.5) !important; }
         .shadow-error\\/50 { --tw-shadow-color: rgba(239, 68, 68, 0.5) !important; }
-        
-        /* Badge variants */
-        .badge-primary { background-color: rgb(59 130 246) !important; color: rgb(255 255 255) !important; }
-        .badge-ghost { background-color: rgba(229, 231, 235, 0.1) !important; }
-        
-        /* Success/Error states */
         .bg-success { background-color: rgb(16 185 129) !important; }
         .bg-error { background-color: rgb(239 68 68) !important; }
-        
-        /* Improve leaderboard text readability for non-self/rival entries */
-        .text-base { color: rgb(229 231 235) !important; }
-        .text-base-content\\/70 { color: rgba(229, 231, 235, 0.9) !important; }
       `;
       document.head.appendChild(style);
-
-      // Remove data-theme attribute when in compat mode
       document.documentElement.removeAttribute('data-theme');
-
       return () => {
-        const styleElement = document.getElementById('compat-mode-colors');
-        if (styleElement) {
-          styleElement.remove();
-        }
+        document.getElementById('compat-mode-colors')?.remove();
       };
     } else {
-      const theme = themeParam || 'arrow-blue'; // Default to arrow-blue if no theme specified
-      document.documentElement.setAttribute('data-theme', theme);
+      document.documentElement.setAttribute('data-theme', themeParam || 'arrow-blue');
     }
-
-    // Set body background to transparent for OBS
     document.body.style.backgroundColor = 'transparent';
     document.documentElement.style.backgroundColor = 'transparent';
-
-    // Cleanup: reset when component unmounts
     return () => {
       document.body.style.backgroundColor = '';
       document.documentElement.style.backgroundColor = '';
     };
   }, [themeParam, compatMode]);
 
-  // Auto-rotate leaderboard based on rotation delay
-  useEffect(() => {
-    if (availableLeaderboards.length <= 1) return; // No rotation needed if only one leaderboard
-
-    const interval = setInterval(() => {
-      setCurrentLeaderboardIndex((prev) => (prev + 1) % availableLeaderboards.length);
-    }, rotationDelay);
-
-    return () => clearInterval(interval);
-  }, [availableLeaderboards.length, rotationDelay]);
-
-  // Auto-scroll leaderboard - oscillate between top and bottom
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setScrollIndex((prev) => {
-        if (scrollDirection === 'down') {
-          if (prev >= maxScrollIndex) {
-            setScrollDirection('up');
-            return prev;
-          }
-          return prev + 1;
-        } else {
-          if (prev <= 0) {
-            setScrollDirection('down');
-            return prev;
-          }
-          return prev - 1;
-        }
-      });
-    }, 2500);
-
-    return () => clearInterval(interval);
-  }, [scrollDirection, maxScrollIndex]);
-
   if (loading) {
     return (
-      <div className="w-full h-screen bg-base-100 flex items-center justify-center p-4">
-        <div style={{ width: `${totalWidth}px`, height: '300px' }} className="bg-base-200 flex items-center justify-center">
-          <div className="loading loading-spinner loading-lg text-primary"></div>
+      <div className="w-full h-screen bg-transparent flex items-center justify-center">
+        <div style={{ width: totalWidth, height: totalHeight }} className="bg-base-200 flex items-center justify-center">
+          <div className="loading loading-spinner loading-lg text-primary" />
         </div>
       </div>
     );
   }
 
+  if (!widgetData) return null;
+
+  const features = config?.features ?? [{ type: 'profile' as const }];
+  const isHorizontal = config?.orientation === 'horizontal';
+
   return (
-    <div className="w-full h-screen flex items-center justify-center p-0">
-      <div
-        style={{ width: `${totalWidth}px`, height: '300px' }}
-        className="bg-gradient-to-br from-base-200 via-base-300 to-base-200 shadow-2xl overflow-hidden relative flex"
-      >
-        {/* Animated gradient overlays for visual interest */}
-        <div className="absolute inset-0 bg-gradient-to-tr from-primary/5 via-transparent to-accent/5 pointer-events-none" />
-        <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
-        <div className="absolute bottom-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-accent/50 to-transparent" />
-
-        {/* Left Side - User Info & Stats */}
-        <div className="w-[235px] flex flex-col p-4 relative z-10">
-          {/* Top - Blue Shift Logo and Leaderboard Badges */}
-          <div className="mb-auto">
-            {/* Blue Shift Logo */}
-            <div className="mb-3 relative">
-              <div className="absolute inset-0 bg-primary/10 blur-2xl" />
-              <img
-                src="https://assets.arrowcloud.dance/logos/20250725/blue shift-t big.png"
-                alt={formatMessage({ defaultMessage: 'Blue Shift', id: 'r2gihF', description: 'Alt text for Blue Shift logo' })}
-                className="h-10 object-contain opacity-90 relative drop-shadow-lg"
-              />
-            </div>
-
-            {/* Leaderboard Mode Indicator */}
-            <motion.div className="flex gap-2" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
-              {availableLeaderboards.includes('HardEX') && (
-                <motion.div
-                  className={`badge ${leaderboard === 'HardEX' ? 'badge-primary shadow-lg shadow-primary/50' : 'badge-ghost'} badge-sm`}
-                  animate={{ scale: leaderboard === 'HardEX' ? 1.25 : 1 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <FormattedMessage defaultMessage="H.EX" description="Abbreviation for Hard EX leaderboard mode" id="T3ze71" />
-                </motion.div>
-              )}
-              {availableLeaderboards.includes('EX') && (
-                <motion.div
-                  className={`badge ${leaderboard === 'EX' ? 'badge-primary shadow-lg shadow-primary/50' : 'badge-ghost'} badge-sm`}
-                  animate={{ scale: leaderboard === 'EX' ? 1.25 : 1 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <FormattedMessage defaultMessage="EX" description="Abbreviation for EX leaderboard mode" id="SpD64Q" />
-                </motion.div>
-              )}
-              {availableLeaderboards.includes('ITG') && (
-                <motion.div
-                  className={`badge ${leaderboard === 'ITG' ? 'badge-primary shadow-lg shadow-primary/50' : 'badge-ghost'} badge-sm`}
-                  animate={{ scale: leaderboard === 'ITG' ? 1.25 : 1 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <FormattedMessage defaultMessage="ITG" description="Abbreviation for ITG leaderboard mode" id="UhnD7Q" />
-                </motion.div>
-              )}
-            </motion.div>
-          </div>
-
-          {/* Bottom - Avatar, Username, and Stats */}
-          <div className="mt-auto">
-            {/* Avatar & Username */}
-            <div className="flex items-center gap-3 mb-3">
-              <div className="relative">
-                <div className="absolute inset-0 bg-primary/20 rounded-full blur-xl" />
-                <ProfileAvatar alias={widgetData?.user.alias || 'Player'} profileImageUrl={widgetData?.user.profileImageUrl || null} size="lg" />
-              </div>
-              <div>
-                <div className="text-xl font-bold text-primary drop-shadow-lg">{widgetData?.user.alias}</div>
-              </div>
-            </div>
-
-            {/* Points and Rank */}
-            {stats && stats.rank > 0 ? (
-              <div className="space-y-1">
-                <motion.div
-                  key={`rank-${leaderboard}`}
-                  initial={{ x: -50, opacity: 0 }}
-                  animate={{ x: 0, opacity: 1 }}
-                  transition={{ duration: 0.3, ease: 'easeInOut', delay: 0 }}
-                  className="flex items-baseline gap-2"
-                >
-                  <span className="text-3xl font-bold text-accent drop-shadow-[0_0_10px_rgba(var(--accent),0.5)]">
-                    <FormattedMessage
-                      defaultMessage="#{rank,number}"
-                      id="tn3SH1"
-                      description="stat indicating a user's overall rank in an event"
-                      values={{ rank: stats.rank }}
-                    />
-                  </span>
-                  <span className="text-md text-base-content/60">
-                    <FormattedMessage
-                      defaultMessage="of {total,number}"
-                      id="vQNNhl"
-                      description="stat indicating total number of participants in an event"
-                      values={{ total: stats.totalParticipants }}
-                    />
-                  </span>
-                </motion.div>
-                <motion.div
-                  key={`points-${leaderboard}`}
-                  initial={{ x: -50, opacity: 0 }}
-                  animate={{ x: 0, opacity: 1 }}
-                  transition={{ duration: 0.3, ease: 'easeInOut', delay: 0.1 }}
-                  className="flex items-baseline gap-2"
-                >
-                  <span className="text-2xl font-bold text-primary drop-shadow-[0_0_10px_rgba(var(--primary),0.5)]">{formatNumber(stats.totalPoints)}</span>
-                  <span className="text-sm text-base-content/60">
-                    <FormattedMessage defaultMessage="points" id="DYk76o" description="Label for points stat" />
-                  </span>
-                </motion.div>
-              </div>
-            ) : (
-              <div className="text-center py-4">
-                <div className="text-sm text-base-content/60">
-                  <FormattedMessage defaultMessage="No scores yet" id="By9s2f" description="Message shown when user has no scores in the event" />
-                </div>
-                <div className="text-xs text-base-content/40 mt-1">
-                  <FormattedMessage defaultMessage="Play some songs to get started!" id="mvXRqN" description="Hint shown when user has no scores" />
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Right Side - Leaderboard */}
-        {showLeaderboard && (
-          <div className="w-[290px] bg-base-300/30 backdrop-blur-sm p-4 flex flex-col relative z-10 border-l border-base-content/10">
-            <div className="flex-1 overflow-hidden relative">
-              <motion.div
-                key={`leaderboard-${leaderboard}`}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.3, ease: 'easeInOut' }}
-              >
-                <motion.div animate={{ y: -scrollIndex * 54 }} transition={{ type: 'spring', stiffness: 100, damping: 20, mass: 0.5 }} className="space-y-2">
-                  {leaderboardWithUser
-                    .filter((entry) => scrollIndex <= 10 || entry.isSelf || entry.isRival)
-                    .map((entry) => (
-                      <div
-                        key={entry.rank}
-                        className={`flex items-center gap-2 px-3 py-2.5 rounded transition-all ${
-                          entry.isSelf
-                            ? 'bg-primary/20 border border-primary/40 shadow-lg shadow-primary/20'
-                            : entry.isRival
-                              ? 'bg-accent/10 border border-accent/30 shadow-md shadow-accent/10'
-                              : 'bg-base-200/50'
-                        }`}
-                      >
-                        {/* Rank */}
-                        <div className={`text-lg font-bold w-10 ${entry.isSelf ? 'text-primary' : entry.isRival ? 'text-accent' : 'text-base-content/60'}`}>
-                          <FormattedMessage
-                            defaultMessage="#{rank,number}"
-                            id="tn3SH1"
-                            description="stat indicating a user's overall rank in an event"
-                            values={{ rank: entry.rank }}
-                          />
-                        </div>
-
-                        {/* Avatar */}
-                        <div className="relative">
-                          {(entry.isSelf || entry.isRival) && (
-                            <div className={`absolute inset-0 ${entry.isSelf ? 'bg-primary/20' : 'bg-accent/20'} rounded-full blur-md`} />
-                          )}
-                          <ProfileAvatar alias={entry.alias} profileImageUrl={entry.profileImageUrl} size="sm" />
-                        </div>
-
-                        {/* Name with Rival Icon */}
-                        <div className="flex items-center gap-1 flex-1 min-w-0">
-                          <div className={`text-base truncate ${entry.isSelf ? 'font-bold text-primary' : entry.isRival ? 'text-accent' : ''}`}>
-                            {entry.alias}
-                          </div>
-                          {entry.isRival && <Swords className="w-3 h-3 text-accent flex-shrink-0 drop-shadow-[0_0_4px_rgba(var(--accent),0.8)]" />}
-                        </div>
-
-                        {/* Points */}
-                        <div className="text-base font-medium text-base-content/70">{formatNumber(entry.points)}</div>
-                      </div>
-                    ))}
-                </motion.div>
-              </motion.div>
-            </div>
-          </div>
-        )}
-
-        {/* Last Played Song */}
-        {showLastPlayed && widgetData?.lastPlayed && (
-          <div className="w-[235px] bg-base-300/30 backdrop-blur-sm p-4 flex flex-col relative z-10 border-l border-base-content/10">
-            <div className="text-xs font-bold text-base-content/70 mb-2 uppercase tracking-wide">
-              <FormattedMessage defaultMessage="Last Played" id="pB9pg4" description="Label for the last played song section" />
-            </div>
-
-            <div className="flex-1 flex flex-col gap-2">
-              {/* Banner */}
-              <div className="relative">
-                <BannerImage
-                  bannerVariants={widgetData.lastPlayed.chart.bannerVariants}
-                  mdBannerUrl={widgetData.lastPlayed.chart.mdBannerUrl}
-                  smBannerUrl={widgetData.lastPlayed.chart.smBannerUrl}
-                  bannerUrl={widgetData.lastPlayed.chart.bannerUrl}
-                  alt={widgetData.lastPlayed.chart.title}
-                  className="w-full rounded shadow-lg object-cover"
-                  style={{ aspectRatio: '2.56' }}
-                  loading="eager"
-                  sizePreference="responsive"
-                />
-              </div>
-
-              {/* Song Info */}
-              <div className="space-y-1">
-                <div className="text-base font-bold text-base-content truncate">{widgetData.lastPlayed.chart.title}</div>
-              </div>
-
-              {/* Last Play Score */}
-              <div className="mt-auto space-y-1.5">
-                <div className="flex items-center gap-2">
-                  <GradeImage grade={widgetData.lastPlayed.scores[leaderboard].lastScore.grade} className="h-7 w-auto drop-shadow-lg" />
-                  <motion.div
-                    key={`last-score-${leaderboard}`}
-                    initial={{ x: -50, opacity: 0 }}
-                    animate={{ x: 0, opacity: 1 }}
-                    transition={{ duration: 0.3, ease: 'easeInOut', delay: 0 }}
-                  >
-                    <span className="text-xl font-bold text-primary drop-shadow-[0_0_10px_rgba(var(--primary),0.5)]">
-                      <FormattedNumber
-                        value={widgetData.lastPlayed.scores[leaderboard].lastScore.score / 100}
-                        style="percent"
-                        minimumFractionDigits={2}
-                        maximumFractionDigits={2}
-                      />
-                    </span>
-                  </motion.div>
-                </div>
-
-                {/* Personal Best Score */}
-                <div className="border-t border-base-content/10 pt-1.5 mt-1.5">
-                  <div className="text-[10px] font-semibold text-base-content/50 uppercase tracking-wider mb-0">
-                    <FormattedMessage defaultMessage="Personal Best" id="+pLe/x" description="Label for the user's best score on this chart" />
-                  </div>
-                  <motion.div
-                    key={`pb-rank-${leaderboard}`}
-                    initial={{ x: -50, opacity: 0 }}
-                    animate={{ x: 0, opacity: 1 }}
-                    transition={{ duration: 0.3, ease: 'easeInOut', delay: 0.05 }}
-                    className="flex items-baseline gap-1.5 mb-1"
-                  >
-                    <span className="text-2xl font-bold text-accent drop-shadow-[0_0_10px_rgba(var(--accent),0.5)]">
-                      <FormattedMessage
-                        defaultMessage="#{rank}"
-                        id="QIi1Qb"
-                        description="Rank of the player on the chart"
-                        values={{ rank: widgetData.lastPlayed.scores[leaderboard].pbScore.rank }}
-                      />
-                    </span>
-                    <span className="text-sm text-base-content/50">
-                      <FormattedMessage
-                        defaultMessage="of {total,number}"
-                        id="vQNNhl"
-                        description="stat indicating total number of participants in an event"
-                        values={{ total: widgetData.lastPlayed.scores[leaderboard].pbScore.totalPlayers }}
-                      />
-                    </span>
-                  </motion.div>
-                  <div className="flex items-center gap-2">
-                    <GradeImage grade={widgetData.lastPlayed.scores[leaderboard].pbScore.grade} className="h-7 w-auto drop-shadow-lg" />
-                    <motion.div
-                      key={`pb-score-${leaderboard}`}
-                      initial={{ x: -50, opacity: 0 }}
-                      animate={{ x: 0, opacity: 1 }}
-                      transition={{ duration: 0.3, ease: 'easeInOut', delay: 0.1 }}
-                    >
-                      <span className="text-xl font-bold text-primary drop-shadow-[0_0_10px_rgba(var(--primary),0.5)]">
-                        <FormattedNumber
-                          value={widgetData.lastPlayed.scores[leaderboard].pbScore.score / 100}
-                          style="percent"
-                          minimumFractionDigits={2}
-                          maximumFractionDigits={2}
-                        />
-                      </span>
-                    </motion.div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Connection Status Indicator */}
-        <div className="absolute top-2 right-2 z-20">
+    <div className="w-full h-screen flex items-center justify-center p-0 bg-transparent">
+      <style>{WIDGET_KEYFRAMES}</style>
+      {/* WebSocket status dot — only visible when WS is configured */}
+      {WS_URL && (
+        <div className="fixed top-2 right-2 z-50">
           <div
             className={`w-2 h-2 rounded-full ${wsConnected ? 'bg-success shadow-lg shadow-success/50' : 'bg-error shadow-lg shadow-error/50'} animate-pulse`}
           />
         </div>
+      )}
+
+      <div style={{ width: totalWidth, height: totalHeight }} className={`flex ${isHorizontal ? 'flex-row' : 'flex-col'} overflow-hidden`}>
+        {features.map((feature, i) => {
+          const orientation = config?.orientation ?? 'vertical';
+          if (feature.type === 'profile') {
+            return <ProfileStatsPanel key={i} user={widgetData.user} orientation={orientation} />;
+          }
+          if (feature.type === 'recentPlays') {
+            return <RecentPlaysPanel key={i} plays={widgetData.recentPlays ?? []} leaderboards={feature.leaderboards} orientation={orientation} />;
+          }
+          if (feature.type === 'packLeaderboard') {
+            const packData = widgetData.packLeaderboards?.[feature.packId];
+            if (!packData) return null;
+            return (
+              <PackLeaderboardPanel
+                key={i}
+                packName={feature.packName}
+                bannerUrl={feature.bannerUrl}
+                data={packData}
+                leaderboards={feature.leaderboards}
+                orientation={orientation}
+              />
+            );
+          }
+          return null;
+        })}
       </div>
     </div>
   );

--- a/frontend/src/pages/widget/panels/PackLeaderboardPanel.tsx
+++ b/frontend/src/pages/widget/panels/PackLeaderboardPanel.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+import React from 'react';
+import { BannerImage } from '../../../components/ui/BannerImage';
+import type { WidgetPackLeaderboard } from '../../../schemas/apiSchemas';
+import { PANEL_WIDTH, PANEL_HEIGHT, COMPACT_HEIGHTS, type LeaderboardKey } from '../../../utils/widgetConfig';
+import { useRotatingIndex } from './useRotatingIndex';
+
+const LB_LABELS: Record<LeaderboardKey, string> = { HardEX: 'H.EX', EX: 'EX', ITG: 'ITG' };
+const LB_COLORS: Record<LeaderboardKey, string> = { HardEX: '#FF69B4', EX: '#21CCE8', ITG: '#ffffff' };
+const FADE_IN: React.CSSProperties = { animation: 'widgetFadeIn 0.4s ease' };
+
+interface Props {
+  packName: string;
+  bannerUrl: string | null;
+  data: WidgetPackLeaderboard;
+  leaderboards: LeaderboardKey[];
+  orientation: 'horizontal' | 'vertical';
+}
+
+export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, data, leaderboards, orientation }) => {
+  const idx = useRotatingIndex(leaderboards.length);
+  const activeLb = leaderboards[idx];
+  const entry = data.leaderboards[activeLb];
+  const lbColor = LB_COLORS[activeLb];
+
+  if (orientation === 'vertical') {
+    return (
+      <div
+        style={{ width: PANEL_WIDTH, height: COMPACT_HEIGHTS.packLeaderboard }}
+        className="relative flex items-center gap-2 px-2 overflow-hidden bg-gradient-to-r from-base-200 via-base-300 to-base-200 border-b border-base-300/30"
+      >
+        <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-accent/5 pointer-events-none" />
+        <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-transparent via-primary/50 to-transparent" />
+
+        {/* Small banner — static */}
+        {bannerUrl && (
+          <div className="flex-shrink-0 rounded overflow-hidden" style={{ width: 51, height: 20 }}>
+            <BannerImage bannerUrl={bannerUrl} alt={packName} className="w-full h-full object-cover" />
+          </div>
+        )}
+
+        <div className="flex-1 min-w-0 z-10">
+          {/* Pack name + badge row */}
+          <div className="flex items-center gap-1 mb-0.5">
+            <span className="text-[11px] font-bold text-base-content/70 truncate">{packName}</span>
+            {/* Badge — fades with leaderboard color */}
+            <span key={activeLb} className="text-[9px] font-bold px-1 py-0.5 rounded bg-black/50 flex-shrink-0" style={{ color: lbColor, ...FADE_IN }}>
+              {LB_LABELS[activeLb]}
+            </span>
+          </div>
+          {/* Rank + score — fades */}
+          {entry ? (
+            <div key={activeLb} className="flex items-baseline gap-2" style={FADE_IN}>
+              <span className="text-xl font-black leading-none" style={{ color: lbColor }}>
+                #{entry.rank}
+              </span>
+              <span className="text-[10px] text-base-content/40">of {entry.totalParticipants}</span>
+              <span className="text-sm font-bold ml-auto" style={{ color: lbColor }}>
+                {entry.totalScore.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                <span className="text-[10px] font-normal text-base-content/40 ml-0.5">pts</span>
+              </span>
+            </div>
+          ) : (
+            <span key={activeLb} className="text-[11px] text-base-content/30" style={FADE_IN}>
+              No scores yet
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Horizontal: banner at top, rank + score below
+  const BANNER_H = 100;
+  const bodyH = PANEL_HEIGHT - BANNER_H;
+
+  return (
+    <div
+      style={{ width: PANEL_WIDTH, height: PANEL_HEIGHT }}
+      className="relative flex flex-col overflow-hidden bg-gradient-to-br from-base-200 via-base-300 to-base-200"
+    >
+      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-accent/50 to-transparent z-10" />
+      <div className="absolute inset-0 bg-gradient-to-tr from-primary/5 via-transparent to-accent/5 pointer-events-none" />
+
+      {/* Banner — static */}
+      <div style={{ height: BANNER_H }} className="flex-shrink-0 relative overflow-hidden">
+        {bannerUrl ? (
+          <BannerImage bannerUrl={bannerUrl} alt={packName} className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full bg-base-300 flex items-center justify-center">
+            <span className="text-xs text-base-content/30 truncate px-2">{packName}</span>
+          </div>
+        )}
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent to-base-200/80" />
+        {/* Badge — fades with leaderboard color */}
+        <div className="absolute bottom-1 right-2">
+          <span key={activeLb} className="text-[11px] font-bold px-1.5 py-0.5 rounded bg-black/60" style={{ color: lbColor, ...FADE_IN }}>
+            {LB_LABELS[activeLb]}
+          </span>
+        </div>
+      </div>
+
+      {/* Rank + score — fades with leaderboard color */}
+      <div style={{ height: bodyH }} className="flex flex-col items-center justify-center z-10 gap-1">
+        <span className="text-xs font-semibold text-base-content/50 truncate px-2 max-w-full">{packName}</span>
+        {entry ? (
+          <div key={activeLb} className="flex flex-col items-center gap-1" style={FADE_IN}>
+            <div className="text-4xl font-black drop-shadow-lg leading-none" style={{ color: lbColor }}>
+              #{entry.rank}
+            </div>
+            <div className="text-xs text-base-content/40">of {entry.totalParticipants}</div>
+            <div className="mt-2 bg-black/30 rounded-lg px-3 py-1 backdrop-blur-sm">
+              <span className="text-xl font-bold" style={{ color: lbColor }}>
+                {entry.totalScore.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                <span className="text-xs font-normal text-base-content/40 ml-1">pts</span>
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div key={activeLb} className="text-sm text-base-content/40" style={FADE_IN}>
+            No scores yet
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/widget/panels/ProfileStatsPanel.tsx
+++ b/frontend/src/pages/widget/panels/ProfileStatsPanel.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ProfileAvatar } from '../../../components';
+import type { WidgetDataResponse } from '../../../schemas/apiSchemas';
+import { PANEL_WIDTH, PANEL_HEIGHT, COMPACT_HEIGHTS, HORIZONTAL_WIDTHS } from '../../../utils/widgetConfig';
+
+interface Props {
+  user: WidgetDataResponse['user'];
+  orientation: 'horizontal' | 'vertical';
+}
+
+export const ProfileStatsPanel: React.FC<Props> = ({ user, orientation }) => {
+  if (orientation === 'vertical') {
+    return (
+      <div
+        style={{ width: PANEL_WIDTH, height: COMPACT_HEIGHTS.profile }}
+        className="relative flex items-center gap-3 px-3 overflow-hidden bg-gradient-to-r from-base-200 via-base-300 to-base-200 border-b border-base-300/30"
+      >
+        <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-transparent via-primary/50 to-transparent" />
+        <div className="relative flex-shrink-0">
+          <div className="absolute inset-0 bg-primary/20 rounded-full blur-md" />
+          <ProfileAvatar alias={user.alias} profileImageUrl={user.profileImageUrl ?? null} size="sm" />
+        </div>
+        <span className="text-sm font-bold text-primary truncate z-10">{user.alias}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{ width: HORIZONTAL_WIDTHS.profile, height: PANEL_HEIGHT }}
+      className="relative flex flex-col items-center justify-center gap-4 overflow-hidden bg-gradient-to-br from-base-200 via-base-300 to-base-200"
+    >
+      <div className="absolute top-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
+      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-accent/50 to-transparent" />
+      <div className="absolute inset-0 bg-gradient-to-tr from-primary/5 via-transparent to-accent/5 pointer-events-none" />
+      <div className="relative z-10">
+        <div className="absolute inset-0 bg-primary/20 rounded-full blur-xl" />
+        <ProfileAvatar alias={user.alias} profileImageUrl={user.profileImageUrl ?? null} size="lg" />
+      </div>
+      <div className="text-xl font-bold text-primary drop-shadow-lg text-center truncate w-full px-4 z-10">{user.alias}</div>
+    </div>
+  );
+};

--- a/frontend/src/pages/widget/panels/RecentPlaysPanel.tsx
+++ b/frontend/src/pages/widget/panels/RecentPlaysPanel.tsx
@@ -1,0 +1,145 @@
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+import React from 'react';
+import { BannerImage } from '../../../components/ui/BannerImage';
+import { GradeImage } from '../../../components/GradeImage';
+import type { WidgetRecentPlay } from '../../../schemas/apiSchemas';
+import { PANEL_WIDTH, PANEL_HEIGHT, COMPACT_HEIGHTS, HORIZONTAL_WIDTHS, type LeaderboardKey } from '../../../utils/widgetConfig';
+import { useRotatingIndex } from './useRotatingIndex';
+
+const LB_LABELS: Record<LeaderboardKey, string> = { HardEX: 'H.EX', EX: 'EX', ITG: 'ITG' };
+const LB_COLORS: Record<LeaderboardKey, string> = { HardEX: '#FF69B4', EX: '#21CCE8', ITG: '#ffffff' };
+const LB_KEY_FOR_TYPE: Record<string, LeaderboardKey> = { HardEX: 'HardEX', EX: 'EX', Money: 'ITG', ITG: 'ITG' };
+
+const MAX_PLAYS = 3;
+const HEADER_H = 28;
+const SCORE_FONT: React.CSSProperties = { fontFamily: "'Nunito', sans-serif", fontWeight: 800 };
+const FADE_IN: React.CSSProperties = { animation: 'widgetFadeIn 0.4s ease' };
+
+interface Props {
+  plays: WidgetRecentPlay[];
+  leaderboards: LeaderboardKey[];
+  orientation: 'horizontal' | 'vertical';
+}
+
+export const RecentPlaysPanel: React.FC<Props> = ({ plays, leaderboards, orientation }) => {
+  const idx = useRotatingIndex(leaderboards.length);
+  const activeLb = leaderboards[idx];
+  const lbColor = LB_COLORS[activeLb];
+
+  const rows = plays.slice(0, MAX_PLAYS).map((play, i) => {
+    const matchingLb = play.leaderboards.find((l) => (LB_KEY_FOR_TYPE[l.leaderboard] ?? l.leaderboard) === activeLb);
+    return {
+      i,
+      title: play.chart.title ?? 'Unknown',
+      score: matchingLb?.data?.score,
+      grade: matchingLb?.data?.grade,
+      chart: play.chart,
+    };
+  });
+
+  if (orientation === 'vertical') {
+    const ROW_H = Math.floor((COMPACT_HEIGHTS.recentPlays - HEADER_H) / MAX_PLAYS);
+    return (
+      <div style={{ width: PANEL_WIDTH, height: COMPACT_HEIGHTS.recentPlays }} className="relative flex flex-col overflow-hidden border-b border-base-300/30">
+        <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-transparent via-accent/50 to-transparent z-10" />
+
+        <div style={{ height: HEADER_H }} className="flex items-center justify-between px-3 flex-shrink-0 border-b border-base-300/20 bg-base-300/60 z-10">
+          <span className="text-[10px] font-bold text-base-content/70 uppercase tracking-wider">Recent Plays</span>
+          <span key={activeLb} className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-black/50 mr-5" style={{ color: lbColor, ...FADE_IN }}>
+            {LB_LABELS[activeLb]}
+          </span>
+        </div>
+
+        {rows.length === 0 ? (
+          <div className="flex items-center justify-center flex-1 text-xs text-base-content/30 bg-base-200">No recent plays</div>
+        ) : (
+          rows.map(({ i, title, score, grade, chart }) => (
+            <div key={i} style={{ height: ROW_H }} className="relative flex-shrink-0 overflow-hidden">
+              <div className="absolute inset-0">
+                <BannerImage
+                  bannerUrl={chart.bannerUrl}
+                  mdBannerUrl={chart.mdBannerUrl}
+                  smBannerUrl={chart.smBannerUrl}
+                  bannerVariants={(chart as any).bannerVariants}
+                  alt={title}
+                  className="w-full h-full object-cover scale-110"
+                />
+                <div className="absolute inset-0 bg-gradient-to-r from-base-300/70 via-base-300/60 to-base-300/80" />
+              </div>
+              <div className="relative z-10 flex items-center gap-2 h-full px-2">
+                <div className="flex-1 min-w-0">
+                  <div className="text-xs font-bold text-white leading-tight truncate drop-shadow">{title}</div>
+                </div>
+                {/* Grade + score in one pill */}
+                <div className="flex items-center gap-1 bg-black/50 rounded px-1 py-0.5 flex-shrink-0">
+                  {grade && <GradeImage grade={grade} className="w-4 h-4" />}
+                  {score && (
+                    <span key={`${i}-${activeLb}`} className="text-xs leading-tight drop-shadow" style={{ ...SCORE_FONT, color: lbColor, ...FADE_IN }}>
+                      {score}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    );
+  }
+
+  // Horizontal
+  const W = HORIZONTAL_WIDTHS['recentPlays'];
+  const ROW_H = Math.floor((PANEL_HEIGHT - HEADER_H) / MAX_PLAYS);
+
+  return (
+    <div style={{ width: W, height: PANEL_HEIGHT }} className="relative flex flex-col overflow-hidden">
+      <div className="absolute top-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-primary/60 to-transparent z-10" />
+      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-accent/60 to-transparent z-10" />
+
+      <div style={{ height: HEADER_H }} className="flex items-center justify-between px-3 flex-shrink-0 bg-base-300/80 z-10 border-b border-base-300/40">
+        <span className="text-xs font-bold text-base-content/80 uppercase tracking-wide">Recent Plays</span>
+        <span key={activeLb} className="text-[11px] font-bold px-1.5 py-0.5 rounded bg-black/50 mr-5" style={{ color: lbColor, ...FADE_IN }}>
+          {LB_LABELS[activeLb]}
+        </span>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="flex items-center justify-center flex-1 text-sm text-base-content/40 bg-base-200">No recent plays</div>
+      ) : (
+        rows.map(({ i, title, score, grade, chart }) => (
+          <div key={i} style={{ height: ROW_H }} className="relative flex-shrink-0 overflow-hidden">
+            <div className="absolute inset-0">
+              <BannerImage
+                bannerUrl={chart.bannerUrl}
+                mdBannerUrl={chart.mdBannerUrl}
+                smBannerUrl={chart.smBannerUrl}
+                bannerVariants={(chart as any).bannerVariants}
+                alt={title}
+                className="w-full h-full object-cover scale-110"
+              />
+              <div className="absolute inset-0 bg-gradient-to-r from-black/75 via-black/40 to-black/65" />
+              <div className="absolute bottom-0 left-0 w-full h-px bg-white/5" />
+            </div>
+
+            <div className="relative z-10 flex items-center h-full px-3 gap-3">
+              {/* Title — takes all available space */}
+              <div className="flex-1 min-w-0">
+                <div className="text-base font-bold text-white leading-tight truncate drop-shadow-md">{title}</div>
+              </div>
+
+              {/* Grade + score in one pill; grade is static, score fades */}
+              <div className="flex items-center gap-1.5 bg-black/55 backdrop-blur-sm rounded-lg px-2 py-1 flex-shrink-0">
+                {grade && <GradeImage grade={grade} className="w-7 h-7 drop-shadow" />}
+                {score && (
+                  <span key={`${i}-${activeLb}`} className="text-base leading-none drop-shadow-md" style={{ ...SCORE_FONT, color: lbColor, ...FADE_IN }}>
+                    {score}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/widget/panels/useRotatingIndex.ts
+++ b/frontend/src/pages/widget/panels/useRotatingIndex.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function useRotatingIndex(length: number, intervalMs = 5000): number {
+  const [idx, setIdx] = useState(0);
+  const lengthRef = useRef(length);
+  lengthRef.current = length;
+
+  useEffect(() => {
+    if (length <= 1) return;
+    const id = setInterval(() => {
+      setIdx((i) => (i + 1) % lengthRef.current);
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [length, intervalMs]);
+
+  return idx;
+}

--- a/frontend/src/schemas/apiSchemas.ts
+++ b/frontend/src/schemas/apiSchemas.ts
@@ -1112,51 +1112,53 @@ export type SessionPlay = z.infer<typeof sessionPlaySchema>;
 export type SessionDetails = z.infer<typeof sessionDetailsSchema>;
 
 // Widget schemas
-export const widgetLeaderboardEntrySchema = z.object({
-  rank: z.number(),
-  alias: z.string(),
-  points: z.number(),
-  profileImageUrl: z.string().nullable(),
-  chartsPlayed: z.number(),
-  isSelf: z.boolean(),
-  isRival: z.boolean(),
+export const widgetUserStatsSchema = z
+  .object({
+    totalPlays: z.number().optional(),
+    chartsPlayed: z.number().optional(),
+    stepsHit: z.number().optional(),
+    quads: z.number().optional(),
+    quints: z.number().optional(),
+    hexes: z.number().optional(),
+  })
+  .nullable()
+  .optional();
+
+export const widgetRecentPlaySchema = z.object({
+  playId: z.number().optional(),
+  chart: z.object({
+    hash: z.string(),
+    title: z.string().nullable(),
+    artist: z.string().nullable(),
+    bannerUrl: z.string().nullable().optional(),
+    mdBannerUrl: z.string().nullable().optional(),
+    smBannerUrl: z.string().nullable().optional(),
+    bannerVariants: bannerVariantsSchema,
+    stepsType: z.string().nullable(),
+    difficulty: z.string().nullable(),
+    meter: z.number().nullable(),
+  }),
+  leaderboards: z.array(
+    z.object({
+      leaderboard: z.string(),
+      data: z.object({
+        score: z.string(),
+        grade: z.string().optional(),
+      }),
+    }),
+  ),
+  createdAt: z.union([z.string(), z.date()]),
 });
 
-export const widgetUserStatsSchema = z.object({
+export const widgetPackLeaderboardEntrySchema = z.object({
   rank: z.number(),
-  totalPoints: z.number(),
-  chartsPlayed: z.number(),
+  totalScore: z.number(),
   totalParticipants: z.number(),
 });
 
-export const widgetLeaderboardDataSchema = z.object({
-  stats: widgetUserStatsSchema,
-  entries: z.array(widgetLeaderboardEntrySchema),
-});
-
-export const widgetLastPlayedChartSchema = z.object({
-  title: z.string(),
-  artist: z.string(),
-  bannerUrl: z.string(),
-  mdBannerUrl: z.string().nullable().optional(),
-  smBannerUrl: z.string().nullable().optional(),
-  bannerVariants: bannerVariantsSchema,
-  hash: z.string(),
-  difficulty: z.string(),
-  meter: z.number().nullable(),
-});
-
-export const widgetLastPlayedScoreSchema = z.object({
-  lastScore: z.object({
-    score: z.number(),
-    grade: z.string(),
-  }),
-  pbScore: z.object({
-    score: z.number(),
-    grade: z.string(),
-    rank: z.number(),
-    totalPlayers: z.number(),
-  }),
+export const widgetPackLeaderboardSchema = z.object({
+  packName: z.string(),
+  leaderboards: z.record(z.string(), widgetPackLeaderboardEntrySchema),
 });
 
 export const widgetDataResponseSchema = z.object({
@@ -1165,32 +1167,14 @@ export const widgetDataResponseSchema = z.object({
     alias: z.string(),
     profileImageUrl: z.string().nullable(),
   }),
-  leaderboards: z
-    .object({
-      HardEX: widgetLeaderboardDataSchema,
-      EX: widgetLeaderboardDataSchema,
-      ITG: widgetLeaderboardDataSchema,
-    })
-    .optional(),
-  lastPlayed: z
-    .object({
-      chart: widgetLastPlayedChartSchema,
-      scores: z.object({
-        HardEX: widgetLastPlayedScoreSchema,
-        EX: widgetLastPlayedScoreSchema,
-        ITG: widgetLastPlayedScoreSchema,
-      }),
-    })
-    .nullable()
-    .optional(),
+  recentPlays: z.array(widgetRecentPlaySchema).optional(),
+  packLeaderboards: z.record(z.string(), widgetPackLeaderboardSchema).optional(),
 });
 
-export type WidgetLeaderboardEntry = z.infer<typeof widgetLeaderboardEntrySchema>;
-export type WidgetUserStats = z.infer<typeof widgetUserStatsSchema>;
-export type WidgetLeaderboardData = z.infer<typeof widgetLeaderboardDataSchema>;
-export type WidgetLastPlayedChart = z.infer<typeof widgetLastPlayedChartSchema>;
-export type WidgetLastPlayedScore = z.infer<typeof widgetLastPlayedScoreSchema>;
 export type WidgetDataResponse = z.infer<typeof widgetDataResponseSchema>;
+export type WidgetRecentPlay = z.infer<typeof widgetRecentPlaySchema>;
+export type WidgetPackLeaderboard = z.infer<typeof widgetPackLeaderboardSchema>;
+export type WidgetPackLeaderboardEntry = z.infer<typeof widgetPackLeaderboardEntrySchema>;
 
 // ----- Notification schemas -----
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -339,6 +339,7 @@ export interface ListPacksParams {
   page?: number;
   limit?: number;
   search?: string;
+  eligibleOnly?: boolean;
   orderBy?: 'name' | 'createdAt' | 'updatedAt' | 'simfileCount' | 'popularity';
   orderDirection?: 'asc' | 'desc';
 }
@@ -349,6 +350,7 @@ export const listPacks = async (params: ListPacksParams = {}): Promise<ListPacks
   if (params.page) searchParams.append('page', params.page.toString());
   if (params.limit) searchParams.append('limit', params.limit.toString());
   if (params.search) searchParams.append('search', params.search);
+  if (params.eligibleOnly) searchParams.append('eligibleOnly', 'true');
   if (params.orderBy) searchParams.append('orderBy', params.orderBy);
   if (params.orderDirection) searchParams.append('orderDirection', params.orderDirection);
 
@@ -852,13 +854,13 @@ export const approveDeviceLoginSession = async (sessionId: string): Promise<Devi
 };
 
 // Widget data
-export const getWidgetData = async (userId: string, features?: string): Promise<WidgetDataResponse> => {
+export const getWidgetData = async (userId: string, config?: string): Promise<WidgetDataResponse> => {
   const params = new URLSearchParams({ userId });
-  if (features) {
-    params.append('features', features);
+  if (config) {
+    params.append('config', config);
   }
-  const response = await api.get(`/widget/blueshift/data?${params.toString()}`);
-  return validateResponse(widgetDataResponseSchema, response.data, '/widget/blueshift/data');
+  const response = await api.get(`/widget/data?${params.toString()}`);
+  return validateResponse(widgetDataResponseSchema, response.data, '/widget/data');
 };
 
 // Notifications

--- a/frontend/src/utils/widgetConfig.ts
+++ b/frontend/src/utils/widgetConfig.ts
@@ -1,0 +1,62 @@
+export type LeaderboardKey = 'HardEX' | 'EX' | 'ITG';
+export type PackLeaderboardDifficulty = 'medium' | 'hard' | 'challenge';
+
+export type WidgetFeatureConfig =
+  | { type: 'profile' }
+  | { type: 'recentPlays'; leaderboards: LeaderboardKey[] }
+  | {
+      type: 'packLeaderboard';
+      packId: number;
+      packName: string;
+      bannerUrl: string | null;
+      difficulty: PackLeaderboardDifficulty;
+      leaderboards: LeaderboardKey[];
+    };
+
+export interface WidgetConfig {
+  version: 1;
+  orientation: 'horizontal' | 'vertical';
+  features: WidgetFeatureConfig[];
+}
+
+export const PANEL_WIDTH = 300;
+export const PANEL_HEIGHT = 240;
+
+// Compact heights used in vertical orientation — each feature type gets a strip
+// Compact heights for vertical orientation strips
+export const COMPACT_HEIGHTS: Record<WidgetFeatureConfig['type'], number> = {
+  profile: 60,
+  recentPlays: 144,
+  packLeaderboard: 80,
+};
+
+// Panel widths for horizontal orientation (profile is narrower — it's just avatar + name)
+export const HORIZONTAL_WIDTHS: Record<WidgetFeatureConfig['type'], number> = {
+  profile: 140,
+  recentPlays: 300,
+  packLeaderboard: 235,
+};
+
+export const ELIGIBLE_PACK_IDS = [101, 102, 131, 346, 348];
+
+export function encodeWidgetConfig(config: WidgetConfig): string {
+  return btoa(JSON.stringify(config));
+}
+
+export function decodeWidgetConfig(encoded: string): WidgetConfig | null {
+  try {
+    return JSON.parse(atob(encoded)) as WidgetConfig;
+  } catch {
+    return null;
+  }
+}
+
+export function getWidgetDimensions(config: WidgetConfig): { width: number; height: number } {
+  if (config.orientation === 'horizontal') {
+    const width = config.features.reduce((sum, f) => sum + HORIZONTAL_WIDTHS[f.type], 0) || PANEL_WIDTH;
+    return { width, height: PANEL_HEIGHT };
+  }
+  // Vertical: sum compact heights per feature type
+  const height = config.features.reduce((sum, f) => sum + COMPACT_HEIGHTS[f.type], 0) || PANEL_HEIGHT;
+  return { width: PANEL_WIDTH, height };
+}

--- a/prisma/migrations/20260628191709_add_simfile_chart_cmod_ineligible/migration.sql
+++ b/prisma/migrations/20260628191709_add_simfile_chart_cmod_ineligible/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "SimfileChart" ADD COLUMN     "cmodIneligible" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -241,8 +241,9 @@ model SimfileChart {
   description String?
   difficulty   String?  // beginner, easy, medium, hard, challenge, edit
   meter       Int?     // difficulty rating from simfile
-  credit      String?  // stepartist from simfile
-  simfile     Simfile  @relation(fields: [simfileId], references: [id], onDelete: Cascade)
+  credit         String?  // stepartist from simfile
+  cmodIneligible Boolean  @default(false)
+  simfile        Simfile  @relation(fields: [simfileId], references: [id], onDelete: Cascade)
   chart       Chart    @relation(fields: [chartHash], references: [hash], onDelete: Cascade)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/scripts/calculate-pack-leaderboard.ts
+++ b/scripts/calculate-pack-leaderboard.ts
@@ -5,11 +5,12 @@
  * Produces a matrix of 9 leaderboards: 3 difficulty slots × 3 scoring systems.
  *
  * Usage:
- *   npx tsx scripts/calculate-pack-leaderboard.ts <packId> [outputPath]
+ *   npx tsx scripts/calculate-pack-leaderboard.ts <packId> [outputPath] [--user <userId>]
  *
  * Examples:
  *   npx tsx scripts/calculate-pack-leaderboard.ts 42
  *   npx tsx scripts/calculate-pack-leaderboard.ts 42 ./output/pack-42-leaderboards.json
+ *   npx tsx scripts/calculate-pack-leaderboard.ts 42 --user abc-123
  */
 
 import * as fs from 'fs';
@@ -19,10 +20,89 @@ import { calculatePackLeaderboards, PACK_LEADERBOARD_DIFFICULTIES, SCORING_SYSTE
 
 const prisma = new PrismaClient();
 
+async function printUserChartBreakdown(packId: number, userId: string) {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`Per-chart breakdown for user ${userId}`);
+  console.log('='.repeat(60));
+
+  // Fetch all charts in the pack with their CMOD flag
+  const simfileCharts = await prisma.simfileChart.findMany({
+    where: {
+      simfile: { packId },
+      difficulty: { in: ['medium', 'hard', 'challenge'] },
+    },
+    select: { chartHash: true, difficulty: true, cmodIneligible: true },
+    orderBy: { difficulty: 'asc' },
+  });
+
+  // Dedupe by chartHash+difficulty
+  const seen = new Set<string>();
+  const charts = simfileCharts.filter((sc) => {
+    const key = `${sc.chartHash}:${sc.difficulty}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  // Fetch user's best play per chart across all leaderboard IDs, with modifiers
+  const rows = await prisma.$queryRaw<
+    Array<{
+      chartHash: string;
+      leaderboardId: number;
+      score: number;
+      speedType: string | null;
+      playId: number;
+    }>
+  >`
+    SELECT DISTINCT ON (p."chartHash", pl."leaderboardId")
+      p."chartHash"                           AS "chartHash",
+      pl."leaderboardId"                      AS "leaderboardId",
+      (pl.data->>'score')::double precision   AS score,
+      (p.modifiers->'speed'->>'type')         AS "speedType",
+      p.id                                    AS "playId"
+    FROM "PlayLeaderboard" pl
+    JOIN "Play" p ON pl."playId" = p.id
+    WHERE p."userId" = ${userId}
+      AND p."chartHash" = ANY(${charts.map((c) => c.chartHash)})
+    ORDER BY p."chartHash", pl."leaderboardId", pl."sortKey" DESC
+  `;
+
+  // Index rows by chartHash+leaderboardId
+  const rowIndex = new Map<string, (typeof rows)[0]>();
+  for (const row of rows) {
+    rowIndex.set(`${row.chartHash}:${row.leaderboardId}`, row);
+  }
+
+  const leaderboardIds: Record<string, number> = { HardEX: 4, EX: 2, ITG: 3 };
+
+  for (const diff of ['medium', 'hard', 'challenge'] as const) {
+    const diffCharts = charts.filter((c) => c.difficulty === diff);
+    if (diffCharts.length === 0) continue;
+    console.log(`\n--- ${diff} ---`);
+
+    for (const sc of diffCharts) {
+      const flag = sc.cmodIneligible ? '[CMOD-INELIGIBLE]' : '              ';
+      console.log(`  ${sc.chartHash}  ${flag}`);
+
+      for (const [system, lbId] of Object.entries(leaderboardIds)) {
+        const row = rowIndex.get(`${sc.chartHash}:${lbId}`);
+        if (!row) {
+          console.log(`    ${system.padEnd(8)} no score`);
+          continue;
+        }
+        const excluded = sc.cmodIneligible && row.speedType === 'C';
+        const status = excluded ? 'EXCLUDED (CMOD)' : 'included';
+        console.log(`    ${system.padEnd(8)} score=${row.score.toFixed(2).padStart(6)}  speedType=${(row.speedType ?? 'null').padEnd(4)}  ${status}`);
+      }
+    }
+  }
+}
+
 (async () => {
-  const packIdArg = process.argv[2];
+  const args = process.argv.slice(2);
+  const packIdArg = args[0];
   if (!packIdArg) {
-    console.error('Usage: npx tsx scripts/calculate-pack-leaderboard.ts <packId> [outputPath]');
+    console.error('Usage: npx tsx scripts/calculate-pack-leaderboard.ts <packId> [outputPath] [--user <userId>]');
     process.exit(1);
   }
 
@@ -31,6 +111,10 @@ const prisma = new PrismaClient();
     console.error(`Invalid pack ID: ${packIdArg}`);
     process.exit(1);
   }
+
+  const userFlagIdx = args.indexOf('--user');
+  const debugUserId = userFlagIdx !== -1 ? args[userFlagIdx + 1] : null;
+  const outputPath = args.find((a) => !a.startsWith('--') && a !== packIdArg && a !== debugUserId) ?? null;
 
   try {
     console.log(`Calculating pack leaderboards for pack ${packId}...\n`);
@@ -63,17 +147,19 @@ const prisma = new PrismaClient();
       }
     }
 
-    // Write JSON output
-    const defaultOutputPath = path.join('output', `pack-${packId}-leaderboards.json`);
-    const outputPath = process.argv[3] || defaultOutputPath;
-
-    const outputDir = path.dirname(outputPath);
-    if (!fs.existsSync(outputDir)) {
-      fs.mkdirSync(outputDir, { recursive: true });
+    if (debugUserId) {
+      await printUserChartBreakdown(packId, debugUserId);
     }
 
-    fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
-    console.log(`JSON written to ${outputPath}`);
+    if (outputPath) {
+      const resolvedOutputPath = path.resolve(outputPath);
+      const outputDir = path.dirname(resolvedOutputPath);
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+      fs.writeFileSync(resolvedOutputPath, JSON.stringify(result, null, 2));
+      console.log(`\nJSON written to ${resolvedOutputPath}`);
+    }
   } catch (error) {
     console.error('Error calculating pack leaderboards:', error);
     process.exit(1);

--- a/scripts/debug-cmod-filter.ts
+++ b/scripts/debug-cmod-filter.ts
@@ -1,0 +1,70 @@
+/**
+ * Debug CMOD filtering for a specific user + chart hash.
+ *
+ * Usage:
+ *   npx tsx scripts/debug-cmod-filter.ts <userId> <chartHash>
+ */
+import { PrismaClient } from '../api/prisma/generated/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const userId = process.argv[2];
+  const chartHash = process.argv[3];
+
+  if (!userId || !chartHash) {
+    console.error('Usage: npx tsx scripts/debug-cmod-filter.ts <userId> <chartHash>');
+    process.exit(1);
+  }
+
+  // 1. Is the chart flagged as CMOD-ineligible?
+  const charts = await prisma.simfileChart.findMany({
+    where: { chartHash },
+    select: { id: true, cmodIneligible: true, difficulty: true, simfileId: true },
+  });
+  console.log('=== SimfileChart rows for hash ===');
+  console.log(JSON.stringify(charts, null, 2));
+
+  // 2. User's plays on this chart with their full modifiers
+  const plays = await prisma.play.findMany({
+    where: { userId, chartHash },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true, modifiers: true, createdAt: true },
+  });
+  console.log('\n=== User plays on this chart (with modifiers) ===');
+  console.log(JSON.stringify(plays, null, 2));
+
+  // 3. PlayLeaderboard entries for those plays
+  for (const play of plays) {
+    const entries = await prisma.playLeaderboard.findMany({
+      where: { playId: play.id },
+      select: { leaderboardId: true, sortKey: true, data: true },
+    });
+    console.log(`\n=== PlayLeaderboard entries for play ${play.id} (${play.createdAt.toISOString()}) ===`);
+    console.log(JSON.stringify(entries, null, 2));
+  }
+
+  // 4. Raw SQL: what does the CMOD filter clause actually see?
+  const rawCheck = await prisma.$queryRaw<Array<{ chartHash: string; speedType: string | null; wouldExclude: boolean }>>`
+    SELECT
+      p."chartHash",
+      (p.modifiers->'speed'->>'type') AS "speedType",
+      (
+        (p."chartHash" = ANY(ARRAY[${chartHash}]::text[]))
+        AND (p.modifiers->'speed'->>'type') IS NOT DISTINCT FROM 'C'
+      ) AS "wouldExclude"
+    FROM "Play" p
+    WHERE p."userId" = ${userId}
+      AND p."chartHash" = ${chartHash}
+    ORDER BY p."createdAt" DESC
+  `;
+  console.log('\n=== CMOD filter evaluation (wouldExclude = true means it should be filtered out) ===');
+  console.log(JSON.stringify(rawCheck, null, 2));
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/set-cmod-ineligible-charts.ts
+++ b/scripts/set-cmod-ineligible-charts.ts
@@ -1,0 +1,60 @@
+/**
+ * Set cmodIneligible = true on SimfileChart rows matching the given chart hashes.
+ *
+ * Usage:
+ *   npx ts-node scripts/set-cmod-ineligible-charts.ts <hash1> [hash2] ...
+ *
+ * To clear the flag on specific hashes, pass --clear:
+ *   npx ts-node scripts/set-cmod-ineligible-charts.ts --clear <hash1> [hash2] ...
+ *
+ * To list all currently flagged charts:
+ *   npx ts-node scripts/set-cmod-ineligible-charts.ts --list
+ */
+import { PrismaClient } from '../api/prisma/generated/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args[0] === '--list') {
+    const flagged = await prisma.simfileChart.findMany({
+      where: { cmodIneligible: true },
+      select: { chartHash: true, difficulty: true, simfileId: true },
+      orderBy: { chartHash: 'asc' },
+    });
+    if (flagged.length === 0) {
+      console.log('No charts are currently flagged as CMOD-ineligible.');
+    } else {
+      console.log(`${flagged.length} chart(s) flagged as CMOD-ineligible:`);
+      for (const row of flagged) {
+        console.log(`  ${row.chartHash}  difficulty=${row.difficulty ?? '?'}  simfileId=${row.simfileId}`);
+      }
+    }
+    return;
+  }
+
+  const clear = args[0] === '--clear';
+  const hashes = clear ? args.slice(1) : args;
+
+  if (hashes.length === 0) {
+    console.error('Usage: set-cmod-ineligible-charts.ts [--clear] <hash1> [hash2] ...');
+    console.error('       set-cmod-ineligible-charts.ts --list');
+    process.exit(1);
+  }
+
+  const result = await prisma.simfileChart.updateMany({
+    where: { chartHash: { in: hashes } },
+    data: { cmodIneligible: !clear },
+  });
+
+  const action = clear ? 'cleared' : 'set';
+  console.log(`cmodIneligible ${action} on ${result.count} SimfileChart row(s) for ${hashes.length} hash(es).`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
This pull request introduces several improvements and new features across the backend and frontend of the Arrow Cloud project. The main highlights include enabling and documenting pack leaderboards for more packs, enhancing the WebSocket notification system, and exposing new filtering options and UI for users. Additionally, the repository structure and environment setup are now better documented.

**Backend Enhancements:**

*Pack Leaderboards & Filtering:*
- Added and exported `ELIGIBLE_PACK_IDS` (packs with leaderboards enabled) in `api/src/utils/pack-leaderboard.ts`, now including multiple pack IDs instead of just one. All related logic now references this shared constant. [[1]](diffhunk://#diff-cf4a37a0a94e996004ccdbdd2607c07ccde3c899153e9f9677e13786fd9e8fe3R9-R11) [[2]](diffhunk://#diff-45f84099ba799360105bb3ab46711ea13c23a49a1e62ae4857950f8991f8c628L5-R7)
- The pack listing API (`listPacks`) now supports an `eligibleOnly` query parameter to filter for packs with leaderboards, using the new `ELIGIBLE_PACK_IDS`. [[1]](diffhunk://#diff-690330e1d12c7e24105da8fd71b0e54aedc20dc0355a677d9ab6a695877fa83eR12) [[2]](diffhunk://#diff-690330e1d12c7e24105da8fd71b0e54aedc20dc0355a677d9ab6a695877fa83eR30-R33) [[3]](diffhunk://#diff-690330e1d12c7e24105da8fd71b0e54aedc20dc0355a677d9ab6a695877fa83eL68-R73) [[4]](diffhunk://#diff-690330e1d12c7e24105da8fd71b0e54aedc20dc0355a677d9ab6a695877fa83eR84-R86)
- Improved leaderboard calculation to exclude CMOD (speed mod) plays for charts flagged as ineligible, by passing a set of ineligible chart hashes and updating the SQL query accordingly. [[1]](diffhunk://#diff-cf4a37a0a94e996004ccdbdd2607c07ccde3c899153e9f9677e13786fd9e8fe3R101-R118) [[2]](diffhunk://#diff-cf4a37a0a94e996004ccdbdd2607c07ccde3c899153e9f9677e13786fd9e8fe3R135-R157) [[3]](diffhunk://#diff-cf4a37a0a94e996004ccdbdd2607c07ccde3c899153e9f9677e13786fd9e8fe3R197) [[4]](diffhunk://#diff-cf4a37a0a94e996004ccdbdd2607c07ccde3c899153e9f9677e13786fd9e8fe3R206-R224)

*WebSocket Notifications:*
- Refactored WebSocket notification logic to use a centralized `sendToUser` service, standardizing message payloads and ensuring URLs are correctly formatted for the AWS API Gateway management API. [[1]](diffhunk://#diff-9e1a454e0511f9c71df8d44f22ff7f462560701c8d257ec19ee54018b770a61fL15-R15) [[2]](diffhunk://#diff-9e1a454e0511f9c71df8d44f22ff7f462560701c8d257ec19ee54018b770a61fL836-L846) [[3]](diffhunk://#diff-e3329f6749f7fed3e63a3ad0b0e2b87431935a3ecf136f417ece952482f30451L9-R10)
- Pack leaderboard recalculation now triggers a real-time WebSocket notification to the user when their pack leaderboard is updated.

*API & Routing:*
- Changed the widget data endpoint from `/widget/blueshift/data` to `/widget/data` for clarity and simplicity.

**Documentation & Frontend:**

*Documentation:*
- Added a high-level `CLAUDE.md` file describing the repository structure, deployment rules, and documentation practices.
- Updated the frontend `README.md` with environment variable setup instructions, specifically for WebSocket integration.

*UI/UX Improvements:*
- Re-enabled the "Streamer Widget" section in the profile edit navigation, making widget configuration accessible to users. [[1]](diffhunk://#diff-f8d4b2448bbcb53b31dc060f63910947d709650a7c10fadc435125d0c99a780dL2-R2) [[2]](diffhunk://#diff-f8d4b2448bbcb53b31dc060f63910947d709650a7c10fadc435125d0c99a780dL74-R89)
- Minor UI tweak to padding in the `AboutCard` component.

These changes collectively improve feature discoverability, real-time user feedback, and documentation, while also laying the groundwork for future pack leaderboard expansion.