### PR TITLE
Add session widget panel and pack player-scores comparison

### DIFF
--- a/api/src/controllers/chart.ts
+++ b/api/src/controllers/chart.ts
@@ -8,11 +8,11 @@ import { APIGatewayProxyResult } from 'aws-lambda';
 import { assetS3UrlToCloudFrontUrl, toCfVariantSet } from '../utils/s3';
 import { z } from 'zod';
 import { processSinglePlay } from '../utils/play-processor';
+import { sendToUser } from '../services/websocket';
 import { publishScoreSubmissionEvent, EVENT_TYPES } from '../utils/events';
 import { GLOBAL_EX_LEADERBOARD_ID, GLOBAL_MONEY_LEADERBOARD_ID, GLOBAL_HARD_EX_LEADERBOARD_ID } from '../utils/leaderboard';
 import { EventRegistry, EventLeaderboardResponse } from '../utils/events/base';
 import { EventLeaderboardService } from '../services/eventLeaderboards';
-import { sendToUser } from '../services/websocket';
 import { resolveChartBanner } from '../utils/chart-banner';
 import { parseLocalDateToUTC } from '../utils/date';
 
@@ -832,16 +832,10 @@ export const scoreSubmission: AuthenticatedRouteHandler = async (event: Authenti
         }),
       ]);
 
-      // Send immediate WebSocket notification for this user's widgets
-      try {
-        await sendToUser(user.id, { type: 'refresh', data: { userId: user.id, reason: 'New score submitted', timestamp: new Date().toISOString() } });
-        console.log(`[WebSocket] Sent refresh notification for user ${user.id}`);
-      } catch (error) {
-        console.error('[WebSocket] Failed to send refresh notification:', error);
-        // Don't fail the request if WebSocket notification fails
-      }
+      // Notify widgets immediately — play is in the DB, recent plays can refresh now
+      sendToUser(user.id, { type: 'playSubmitted', data: { userId: user.id } }).catch(() => {});
 
-      // Process the play for leaderboards (pass submission data to avoid S3 fetch)
+      // Process the play for leaderboards
       try {
         await processSinglePlay(newPlay, prisma, s3Client, scoreSubmission);
       } catch (error) {
@@ -849,6 +843,7 @@ export const scoreSubmission: AuthenticatedRouteHandler = async (event: Authenti
         // Don't return an error response here - the play was created successfully,
         // we just failed to process leaderboards. This can be retried later.
       }
+      // sessionUpdate is broadcast by the user-stats SQS consumer after writing the session.
 
       // Publish score submission event to SNS
       try {

--- a/api/src/controllers/pack.ts
+++ b/api/src/controllers/pack.ts
@@ -1,5 +1,5 @@
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { PrismaClient } from '../../prisma/generated/client';
+import { PrismaClient, Prisma } from '../../prisma/generated/client';
 import { ExtendedAPIGatewayProxyEvent } from '../utils/types';
 import { z } from 'zod';
 import { assetS3UrlToCloudFrontUrl, toCfVariantSet, S3_BUCKET_ASSETS } from '../utils/s3';
@@ -580,6 +580,173 @@ export async function getPack(event: ExtendedAPIGatewayProxyEvent, prisma: Prism
   } catch (error) {
     console.error('Error getting pack:', error);
 
+    return respond(500, { error: 'Internal server error' });
+  }
+}
+
+/**
+ * Get all chart scores for one or more players in a pack
+ * GET /v1/pack/{packId}/player-scores?userId=...&userId=...
+ */
+export async function getPackPlayerScores(event: ExtendedAPIGatewayProxyEvent, prisma: PrismaClient): Promise<APIGatewayProxyResult> {
+  try {
+    if (!event.routeParameters?.packId) {
+      return respond(400, { error: 'Pack ID is required' });
+    }
+
+    const packId = parseInt(event.routeParameters.packId, 10);
+    if (isNaN(packId)) {
+      return respond(400, { error: 'Invalid pack ID' });
+    }
+
+    // userIds passed as comma-separated: ?userIds=id1,id2,...
+    const rawUserIds = event.queryStringParameters?.userIds ?? '';
+    const userIds = rawUserIds
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (userIds.length === 0) {
+      return respond(400, { error: 'At least one userId is required' });
+    }
+
+    // Verify pack exists
+    const pack = await prisma.pack.findUnique({ where: { id: packId }, select: { id: true } });
+    if (!pack) {
+      return respond(404, { error: 'Pack not found' });
+    }
+
+    // Fetch simfiles in the pack with their medium/hard/challenge charts
+    const simfilesRaw = await prisma.simfile.findMany({
+      where: { packId },
+      select: {
+        id: true,
+        title: true,
+        artist: true,
+        bannerUrl: true,
+        mdBannerUrl: true,
+        smBannerUrl: true,
+        bannerVariants: true,
+        charts: {
+          where: { difficulty: { in: ['medium', 'hard', 'challenge'] } },
+          select: {
+            difficulty: true,
+            chartHash: true,
+            meter: true,
+            stepsType: true,
+          },
+        },
+      },
+      orderBy: { title: 'asc' },
+    });
+
+    // Build simfiles structure
+    const simfiles = simfilesRaw.map((sf) => {
+      const charts: Record<string, { hash: string; meter: number | null; stepsType: string | null }> = {};
+      for (const sc of sf.charts) {
+        if (sc.difficulty) {
+          charts[sc.difficulty] = {
+            hash: sc.chartHash,
+            meter: sc.meter ?? null,
+            stepsType: sc.stepsType ?? null,
+          };
+        }
+      }
+      return {
+        simfileId: sf.id,
+        title: sf.title,
+        artist: sf.artist,
+        bannerUrl: sf.bannerUrl ? assetS3UrlToCloudFrontUrl(sf.bannerUrl) : null,
+        mdBannerUrl: sf.mdBannerUrl ? assetS3UrlToCloudFrontUrl(sf.mdBannerUrl) : null,
+        smBannerUrl: sf.smBannerUrl ? assetS3UrlToCloudFrontUrl(sf.smBannerUrl) : null,
+        bannerVariants: toCfVariantSet(sf.bannerVariants) || undefined,
+        charts,
+      };
+    });
+
+    // Collect all chart hashes from this pack
+    const allChartHashes = simfilesRaw.flatMap((sf) => sf.charts.map((sc) => sc.chartHash));
+
+    // Leaderboard ID → key mapping
+    const LEADERBOARD_KEY_MAP: Record<number, 'ITG' | 'EX' | 'HardEX'> = {
+      [GLOBAL_MONEY_LEADERBOARD_ID]: 'ITG',
+      [GLOBAL_EX_LEADERBOARD_ID]: 'EX',
+      [GLOBAL_HARD_EX_LEADERBOARD_ID]: 'HardEX',
+    };
+
+    // Perfect grade override per leaderboard key
+    const PERFECT_GRADE: Record<string, string> = {
+      ITG: 'quad',
+      EX: 'quint',
+      HardEX: 'hex',
+    };
+
+    const lbIds = [GLOBAL_MONEY_LEADERBOARD_ID, GLOBAL_EX_LEADERBOARD_ID, GLOBAL_HARD_EX_LEADERBOARD_ID];
+
+    // Query best scores per user/chart/leaderboard
+    const bestScores = await prisma.$queryRaw<
+      Array<{
+        userId: string;
+        chartHash: string;
+        leaderboardId: number;
+        data: any;
+      }>
+    >(
+      Prisma.sql`
+        SELECT DISTINCT ON (p."userId", p."chartHash", pl."leaderboardId")
+          p."userId",
+          p."chartHash",
+          pl."leaderboardId",
+          pl.data
+        FROM "Play" p
+        JOIN "PlayLeaderboard" pl ON pl."playId" = p.id
+        WHERE p."userId"::text IN (${Prisma.join(userIds.map((id) => Prisma.sql`${id}`))})
+          AND p."chartHash" IN (${Prisma.join(allChartHashes.map((h) => Prisma.sql`${h}`))})
+          AND pl."leaderboardId" IN (${Prisma.join(lbIds.map((id) => Prisma.sql`${id}`))})
+        ORDER BY p."userId", p."chartHash", pl."leaderboardId", pl."sortKey" DESC
+      `,
+    );
+
+    // Build per-player score maps
+    type ScoreEntry = { score: string; grade: string };
+    type ChartScores = { EX?: ScoreEntry; ITG?: ScoreEntry; HardEX?: ScoreEntry };
+    const playerScoreMap: Record<string, Record<string, ChartScores>> = {};
+
+    for (const row of bestScores) {
+      const lbKey = LEADERBOARD_KEY_MAP[row.leaderboardId];
+      if (!lbKey) continue;
+      const userId = row.userId;
+      if (!playerScoreMap[userId]) playerScoreMap[userId] = {};
+      if (!playerScoreMap[userId][row.chartHash]) playerScoreMap[userId][row.chartHash] = {};
+
+      const data = row.data as { score?: string; grade?: string } | null;
+      const score = data?.score ?? '';
+      let grade = data?.grade ?? '';
+
+      // Perfect score override
+      if (data?.score === '100.00') {
+        grade = PERFECT_GRADE[lbKey];
+      }
+
+      playerScoreMap[userId][row.chartHash][lbKey] = { score, grade };
+    }
+
+    // Fetch user info
+    const users = await prisma.user.findMany({
+      where: { id: { in: userIds } },
+      select: { id: true, alias: true, profileImageUrl: true },
+    });
+
+    const players = users.map((u) => ({
+      userId: u.id,
+      alias: u.alias,
+      profileImageUrl: u.profileImageUrl ? assetS3UrlToCloudFrontUrl(u.profileImageUrl) : null,
+      scores: playerScoreMap[u.id] ?? {},
+    }));
+
+    return respond(200, { simfiles, players });
+  } catch (error) {
+    console.error('Error getting pack player scores:', error);
     return respond(500, { error: 'Internal server error' });
   }
 }

--- a/api/src/controllers/widget.ts
+++ b/api/src/controllers/widget.ts
@@ -7,6 +7,7 @@ import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import { resolveChartBanner } from '../utils/chart-banner';
 import { GLOBAL_HARD_EX_LEADERBOARD_ID, GLOBAL_EX_LEADERBOARD_ID, GLOBAL_MONEY_LEADERBOARD_ID } from '../utils/leaderboard';
 import { type ScoringSystemKey, type PackLeaderboardDifficulty } from '../utils/pack-leaderboard';
+import { countPerfectScores } from '../utils/stats-utils';
 
 const s3Client = new S3Client();
 
@@ -15,7 +16,8 @@ type LeaderboardKey = 'HardEX' | 'EX' | 'ITG';
 type WidgetFeatureConfig =
   | { type: 'profile' }
   | { type: 'recentPlays'; leaderboards: LeaderboardKey[] }
-  | { type: 'packLeaderboard'; packId: number; packName: string; difficulty: PackLeaderboardDifficulty; leaderboards: LeaderboardKey[] };
+  | { type: 'packLeaderboard'; packId: number; packName: string; difficulty: PackLeaderboardDifficulty; leaderboards: LeaderboardKey[] }
+  | { type: 'currentSession' };
 
 interface WidgetConfig {
   version: 1;
@@ -132,6 +134,40 @@ async function getRecentPlaysForWidget(userId: string, leaderboardIds: number[],
   });
 }
 
+function buildNearbyPlayers(
+  rankings: any[],
+  users: Record<string, { alias: string; profileImageUrl: string | null }>,
+  userId: string,
+  rivalIds: Set<string>,
+  maxEntries = 5,
+) {
+  const userEntry = rankings.find((r) => r.userId === userId);
+  if (!userEntry) return [];
+
+  const rivals = rankings
+    .filter((r) => rivalIds.has(r.userId))
+    .sort((a, b) => Math.abs(a.rank - userEntry.rank) - Math.abs(b.rank - userEntry.rank))
+    .slice(0, maxEntries - 1);
+
+  const usedIds = new Set([userId, ...rivals.map((r) => r.userId)]);
+
+  const others = rankings
+    .filter((r) => !usedIds.has(r.userId))
+    .sort((a, b) => Math.abs(a.rank - userEntry.rank) - Math.abs(b.rank - userEntry.rank))
+    .slice(0, maxEntries - 1 - rivals.length);
+
+  return [userEntry, ...rivals, ...others]
+    .sort((a, b) => a.rank - b.rank)
+    .map((r) => ({
+      userId: r.userId,
+      alias: users[r.userId]?.alias ?? 'Unknown',
+      rank: r.rank,
+      totalScore: r.totalScore,
+      isRival: rivalIds.has(r.userId),
+      isSelf: r.userId === userId,
+    }));
+}
+
 /**
  * Get widget data for a user.
  * GET /widget/data?userId={userId}&config={base64}
@@ -149,6 +185,7 @@ export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma:
   const recentPlaysFeature = config?.features.find((f): f is Extract<WidgetFeatureConfig, { type: 'recentPlays' }> => f.type === 'recentPlays');
   const packLeaderboardFeatures =
     config?.features.filter((f): f is Extract<WidgetFeatureConfig, { type: 'packLeaderboard' }> => f.type === 'packLeaderboard') ?? [];
+  const hasCurrentSessionFeature = config?.features.some((f) => f.type === 'currentSession') ?? false;
 
   try {
     const user = await prisma.user.findUnique({
@@ -157,6 +194,7 @@ export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma:
         id: true,
         alias: true,
         profileImageUrl: true,
+        country: { select: { code: true } },
       },
     });
 
@@ -166,32 +204,46 @@ export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma:
 
     const recentPlaysLeaderboardIds = recentPlaysFeature ? recentPlaysFeature.leaderboards.map((k) => LB_KEY_TO_ID[k]) : [];
 
-    const [recentPlays, ...packLeaderboardResults] = await Promise.all([
+    const SESSION_GAP_MS = 1 * 60 * 60 * 1000;
+
+    const [recentPlays, latestSession, rivalRows, ...packLeaderboardResults] = await Promise.all([
       recentPlaysFeature ? getRecentPlaysForWidget(userId, recentPlaysLeaderboardIds, prisma) : Promise.resolve(null),
+      hasCurrentSessionFeature
+        ? prisma.userSession.findFirst({
+            where: { userId: user.id },
+            orderBy: { startedAt: 'desc' },
+            select: { startedAt: true, endedAt: true, playCount: true, distinctCharts: true, stepsHit: true },
+          })
+        : Promise.resolve(null),
+      packLeaderboardFeatures.length > 0 ? prisma.userRival.findMany({ where: { userId: user.id }, select: { rivalUserId: true } }) : Promise.resolve([]),
       ...packLeaderboardFeatures.map((f) => loadPackLeaderboardS3(f.packId)),
     ]);
+
+    const rivalIds = new Set((rivalRows as { rivalUserId: string }[]).map((r) => r.rivalUserId));
 
     const packLeaderboards: Record<number, any> = {};
     packLeaderboardFeatures.forEach((f, i) => {
       const s3Data = packLeaderboardResults[i];
       if (!s3Data) {
-        packLeaderboards[f.packId] = { packName: f.packName, leaderboards: {} };
+        packLeaderboards[f.packId] = { packName: f.packName, difficulty: f.difficulty, leaderboards: {} };
         return;
       }
       const lbData: Record<string, any> = {};
       for (const lbKey of f.leaderboards) {
         const systemData = s3Data.leaderboards?.[f.difficulty]?.[lbKey as ScoringSystemKey];
         if (!systemData) continue;
-        const entry = systemData.rankings?.find((r: any) => r.userId === userId);
+        const rankings: any[] = systemData.rankings ?? [];
+        const entry = rankings.find((r) => r.userId === userId);
         if (entry) {
           lbData[lbKey] = {
             rank: entry.rank,
             totalScore: entry.totalScore,
             totalParticipants: systemData.totalParticipants,
+            nearby: buildNearbyPlayers(rankings, s3Data.users ?? {}, userId, rivalIds),
           };
         }
       }
-      packLeaderboards[f.packId] = { packName: f.packName, leaderboards: lbData };
+      packLeaderboards[f.packId] = { packName: f.packName, difficulty: f.difficulty, leaderboards: lbData };
     });
 
     const response: any = {
@@ -199,6 +251,7 @@ export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma:
         id: user.id,
         alias: user.alias,
         profileImageUrl: user.profileImageUrl ? assetS3UrlToCloudFrontUrl(user.profileImageUrl) : null,
+        countryCode: user.country?.code ?? null,
       },
     };
 
@@ -208,6 +261,47 @@ export const getWidgetData = async (event: ExtendedAPIGatewayProxyEvent, prisma:
 
     if (packLeaderboardFeatures.length > 0) {
       response.packLeaderboards = packLeaderboards;
+    }
+
+    if (hasCurrentSessionFeature) {
+      if (latestSession) {
+        const isOngoing = Date.now() - latestSession.endedAt.getTime() < SESSION_GAP_MS;
+
+        const sessionPlays = await prisma.play.findMany({
+          where: {
+            userId: user.id,
+            createdAt: { gte: latestSession.startedAt, lte: latestSession.endedAt },
+          },
+          select: {
+            chartHash: true,
+            chart: {
+              select: {
+                meter: true,
+                simfiles: { select: { simfile: { select: { packId: true } } } },
+              },
+            },
+            PlayLeaderboard: {
+              where: { leaderboardId: { in: [GLOBAL_MONEY_LEADERBOARD_ID, GLOBAL_EX_LEADERBOARD_ID, GLOBAL_HARD_EX_LEADERBOARD_ID] } },
+              select: { leaderboardId: true, data: true },
+            },
+          },
+        });
+        const { quads, quints, hexes } = countPerfectScores(sessionPlays);
+
+        response.currentSession = {
+          startedAt: latestSession.startedAt.toISOString(),
+          endedAt: latestSession.endedAt.toISOString(),
+          playCount: latestSession.playCount,
+          distinctCharts: latestSession.distinctCharts,
+          stepsHit: latestSession.stepsHit,
+          isOngoing,
+          quads,
+          quints,
+          hexes,
+        };
+      } else {
+        response.currentSession = null;
+      }
     }
 
     return respond(200, response);

--- a/api/src/routes/web.ts
+++ b/api/src/routes/web.ts
@@ -13,7 +13,7 @@ import {
   getUserPasskeys,
   deletePasskey,
 } from '../controllers/auth';
-import { getPack, listPacks, getPackRecentPlays } from '../controllers/pack';
+import { getPack, listPacks, getPackRecentPlays, getPackPlayerScores } from '../controllers/pack';
 import { listUsers } from '../controllers/users';
 import { getPackUploadUrl } from '../controllers/pack-upload';
 import { getSimfile, listSimfiles } from '../controllers/simfile';
@@ -221,6 +221,15 @@ export const webRoutes: Routes = {
   '/pack/{packId}/recent-plays': {
     GET: {
       handler: getPackRecentPlays,
+      requiresAuth: false,
+      patternMatching: {
+        packId: /\d+/,
+      },
+    },
+  },
+  '/pack/{packId}/player-scores': {
+    GET: {
+      handler: getPackPlayerScores,
       requiresAuth: false,
       patternMatching: {
         packId: /\d+/,

--- a/api/src/user-stats.ts
+++ b/api/src/user-stats.ts
@@ -12,6 +12,7 @@ import {
   isPlayEligibleForPerfectScores,
 } from './utils/stats-utils';
 import { checkAndAssignPerfectScoreTrophies } from './utils/trophy-assignment';
+import { sendToUser } from './services/websocket';
 
 let prisma: PrismaClient | undefined;
 
@@ -62,7 +63,7 @@ function getDateStringInTimezone(date: Date = new Date(), timezone: string = 'UT
 }
 
 // Session gap threshold (2 hours in milliseconds)
-const SESSION_GAP_MS = 2 * 60 * 60 * 1000;
+const SESSION_GAP_MS = 1 * 60 * 60 * 1000;
 
 /**
  * Process a single score submission event and update user stats
@@ -289,6 +290,7 @@ async function updateUserSession(
       });
 
       console.log(`Updated session ${latestSession.id} for user ${userId}: playCount=${latestSession.playCount + 1}, distinctCharts=${distinctCharts}`);
+      await sendToUser(userId, { type: 'sessionUpdate', data: { userId } }).catch(() => {});
       return;
     }
   }
@@ -313,6 +315,7 @@ async function updateUserSession(
   });
 
   console.log(`Created new session ${newSession.id} for user ${userId}`);
+  await sendToUser(userId, { type: 'sessionUpdate', data: { userId } }).catch(() => {});
 }
 
 // Minimum session requirements

--- a/cdk/lib/api-stack.ts
+++ b/cdk/lib/api-stack.ts
@@ -395,7 +395,7 @@ export class ApiStack extends cdk.Stack {
       events: [
         new lambdaEventSources.SqsEventSource(userStatsQueue, {
           batchSize: 10,
-          maxBatchingWindow: cdk.Duration.seconds(5),
+          maxBatchingWindow: cdk.Duration.seconds(0),
           reportBatchItemFailures: true,
         }),
       ],
@@ -627,6 +627,12 @@ export class ApiStack extends cdk.Stack {
     apiLambda.addEnvironment('CONNECTIONS_TABLE_NAME', websocketConnectionsTable.tableName);
     apiLambda.addToRolePolicy(wsApiManagementPolicy);
     websocketConnectionsTable.grantReadData(apiLambda);
+
+    // Add to user stats Lambda so it can broadcast sessionUpdate after writing the session
+    userStatsLambda.addEnvironment('WEBSOCKET_API_URL', wsApiUrl);
+    userStatsLambda.addEnvironment('CONNECTIONS_TABLE_NAME', websocketConnectionsTable.tableName);
+    userStatsLambda.addToRolePolicy(wsApiManagementPolicy);
+    websocketConnectionsTable.grantReadData(userStatsLambda);
 
     new cdk.CfnOutput(this, 'WebSocketApiUrl', {
       value: wsApiUrl,

--- a/frontend/src/components/AnimatedRoutes.tsx
+++ b/frontend/src/components/AnimatedRoutes.tsx
@@ -4,6 +4,7 @@ import PageTransition from './PageTransition';
 import { ProtectedRoute } from './';
 import { PacksPage } from '../pages/packs/PacksPage';
 import { PackPage } from '../pages/packs/PackPage';
+import { PackScoresPage } from '../pages/packs/PackScoresPage';
 import { UsersPage } from '../pages/users';
 import { ChartsPage } from '../pages/charts';
 import { ChartPage } from '../pages/charts';
@@ -60,6 +61,8 @@ const AnimatedRoutes = () => {
           <Route path="/user/:userId/perfect-scores/:scoreType" element={<UserPerfectScoresPage />} />
           <Route path="/packs" element={<PacksPage />} />
           <Route path="/pack/:id" element={<PackPage />} />
+          <Route path="/pack/:packId/player/:userId" element={<PackScoresPage />} />
+          <Route path="/pack/:packId/compare" element={<PackScoresPage />} />
           <Route path="/users" element={<UsersPage />} />
           <Route path="/charts" element={<ChartsPage />} />
           <Route path="/chart/:chartHash" element={<ChartPage />} />

--- a/frontend/src/components/leaderboards/PackLeaderboard.tsx
+++ b/frontend/src/components/leaderboards/PackLeaderboard.tsx
@@ -4,7 +4,7 @@ import { Trophy } from 'lucide-react';
 import { ProfileAvatar, Pagination } from '../ui';
 import { LeaderboardToggle } from '../leaderboards/LeaderboardToggle';
 import { useLeaderboardView } from '../../contexts/LeaderboardViewContext';
-import { FormattedMessage, FormattedNumber } from 'react-intl';
+import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 import { getStoredUser, computeHighlight, HighlightedAlias } from '../../utils/rivalHighlight';
 import type { PackLeaderboardData } from '../../schemas/apiSchemas';
 
@@ -42,9 +42,11 @@ interface LeaderboardTableProps {
   users: PackLeaderboardData['users'];
   page: number;
   onPageChange: (page: number) => void;
+  packId: number;
 }
 
-const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ leaderboard, users, page, onPageChange }) => {
+const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ leaderboard, users, page, onPageChange, packId }) => {
+  const { formatMessage } = useIntl();
   const storedUser = getStoredUser();
   const rivalIds: string[] = storedUser?.rivalUserIds || [];
 
@@ -81,7 +83,12 @@ const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ leaderboard, users,
           return (
             <Link
               key={entry.userId}
-              to={`/user/${entry.userId}`}
+              to={`/pack/${packId}/player/${entry.userId}`}
+              title={formatMessage({
+                defaultMessage: 'View scores in this pack',
+                id: '7gwiId',
+                description: "Tooltip on a pack leaderboard row linking to a player's scores in the pack",
+              })}
               className={`flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-base-200/50 transition-colors group ${highlight.rowGradientClass}`}
             >
               <div className="w-7 text-center shrink-0">
@@ -113,9 +120,10 @@ const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ leaderboard, users,
 
 interface PackLeaderboardProps {
   data?: PackLeaderboardData | null;
+  packId: number;
 }
 
-export const PackLeaderboard: React.FC<PackLeaderboardProps> = ({ data }) => {
+export const PackLeaderboard: React.FC<PackLeaderboardProps> = ({ data, packId }) => {
   const { activeLeaderboard } = useLeaderboardView();
   const [activeDifficulty, setActiveDifficultyState] = useState<string>(() => localStorage.getItem(DIFFICULTY_LS_KEY) || 'challenge');
   const [page, setPage] = useState(1);
@@ -172,7 +180,7 @@ export const PackLeaderboard: React.FC<PackLeaderboardProps> = ({ data }) => {
 
         {/* Leaderboard content */}
         {currentLeaderboard ? (
-          <LeaderboardTable leaderboard={currentLeaderboard} users={data.users} page={page} onPageChange={setPage} />
+          <LeaderboardTable leaderboard={currentLeaderboard} users={data.users} page={page} onPageChange={setPage} packId={packId} />
         ) : (
           <div className="text-center py-8 text-base-content/50">
             <Trophy size={32} className="mx-auto mb-2 text-base-content/30" />

--- a/frontend/src/pages/packs/PackPage.tsx
+++ b/frontend/src/pages/packs/PackPage.tsx
@@ -706,7 +706,7 @@ export const PackPage: React.FC = () => {
           {/* Left Column - Pack Metadata + Leaderboard */}
           <div className="lg:col-span-1 space-y-6">
             <PackMetadataCard pack={pack} />
-            <PackLeaderboard data={pack.packLeaderboard} />
+            <PackLeaderboard data={pack.packLeaderboard} packId={pack.id} />
           </div>
 
           {/* Right Column - Recent Scores */}

--- a/frontend/src/pages/packs/PackScoresPage.tsx
+++ b/frontend/src/pages/packs/PackScoresPage.tsx
@@ -1,0 +1,359 @@
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+import React, { useEffect, useState, useMemo } from 'react';
+import { useParams, useSearchParams, useNavigate, Link } from 'react-router-dom';
+import { ArrowLeft, Loader2, X, Plus } from 'lucide-react';
+import { AppPageLayout, Alert, GradeImage } from '../../components';
+import { BannerImage, ProfileAvatar } from '../../components/ui';
+import { LeaderboardToggle } from '../../components/leaderboards/LeaderboardToggle';
+import { useLeaderboardView } from '../../contexts/LeaderboardViewContext';
+import { getPackPlayerScores, getPack } from '../../services/api';
+import { FormattedNumber } from 'react-intl';
+import type { PackPlayerScoresResponse, PackPlayerScoreSimfile, PackPlayerScoresPlayer } from '../../schemas/apiSchemas';
+import type { LeaderboardId } from '../../types/leaderboards';
+
+type DifficultyKey = 'medium' | 'hard' | 'challenge';
+
+const DIFFICULTY_COLS: { key: DifficultyKey; label: string }[] = [
+  { key: 'medium', label: 'Med' },
+  { key: 'hard', label: 'Hard' },
+  { key: 'challenge', label: 'Expert' },
+];
+
+type ScoreEntry = { score: string; grade: string };
+type ChartScoreMap = Record<string, { EX?: ScoreEntry; ITG?: ScoreEntry; HardEX?: ScoreEntry }>;
+
+type WinState = 'winner' | 'loser' | 'none';
+
+interface ScoreContext {
+  state: WinState;
+  diff: number | null; // percentage-point diff vs reference (positive=won by, negative=behind by)
+}
+
+interface ScoreCellProps {
+  player: PackPlayerScoresPlayer;
+  simfile: PackPlayerScoreSimfile;
+  diffKey: DifficultyKey;
+  lbKey: LeaderboardId;
+  ctx: ScoreContext;
+}
+
+const ScoreCell: React.FC<ScoreCellProps> = ({ player, simfile, diffKey, lbKey, ctx }) => {
+  const chart = simfile.charts[diffKey];
+
+  if (!chart) {
+    return <td className="text-center text-base-content/20 text-sm px-2 py-3 border-l border-base-content/10">·</td>;
+  }
+
+  const entry = (player.scores as ChartScoreMap)[chart.hash]?.[lbKey];
+
+  if (!entry) {
+    return <td className="text-center text-base-content/30 text-sm px-2 py-3 border-l border-base-content/10">—</td>;
+  }
+
+  const { state, diff } = ctx;
+  const scoreClass = state === 'winner' ? 'text-primary' : state === 'loser' ? 'text-base-content/45' : 'text-base-content/80';
+  const showDiff = diff !== null && diff !== 0;
+  const diffLabel = showDiff ? `${diff > 0 ? '+' : ''}${diff.toFixed(2)}%` : null;
+
+  return (
+    <td className="text-center px-3 py-3 border-l border-base-content/10">
+      <div className="flex items-center justify-center gap-1.5">
+        <GradeImage grade={entry.grade} className={`w-8 h-8 object-contain ${state === 'loser' ? 'opacity-50' : ''}`} />
+        <div className="flex flex-col items-start">
+          <span className={`font-bold text-base tabular-nums leading-tight ${scoreClass}`}>
+            <FormattedNumber value={parseFloat(entry.score) / 100} style="percent" maximumFractionDigits={2} minimumFractionDigits={2} />
+          </span>
+          {diffLabel && <span className={`text-xs tabular-nums leading-tight ${state === 'winner' ? 'text-success' : 'text-error'}`}>{diffLabel}</span>}
+        </div>
+      </div>
+    </td>
+  );
+};
+
+function getScoreContext(
+  allPlayers: PackPlayerScoresPlayer[],
+  player: PackPlayerScoresPlayer,
+  chartHash: string | undefined,
+  lbKey: LeaderboardId,
+): ScoreContext {
+  if (!chartHash) return { state: 'none', diff: null };
+  const playerScores = allPlayers
+    .map((p) => ({ userId: p.userId, val: parseFloat((p.scores as ChartScoreMap)[chartHash]?.[lbKey]?.score ?? '') }))
+    .filter((x) => !isNaN(x.val));
+  if (playerScores.length < 2) return { state: 'none', diff: null };
+  const sorted = [...playerScores].sort((a, b) => b.val - a.val);
+  const maxVal = sorted[0].val;
+  const myScore = playerScores.find((x) => x.userId === player.userId);
+  if (!myScore) return { state: 'none', diff: null };
+  if (myScore.val >= maxVal) {
+    const secondVal = sorted[1].val;
+    return { state: 'winner', diff: maxVal - secondVal };
+  }
+  return { state: 'loser', diff: myScore.val - maxVal };
+}
+
+export const PackScoresPage: React.FC = () => {
+  const { packId, userId: routeUserId } = useParams<{ packId: string; userId?: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { activeLeaderboard } = useLeaderboardView();
+
+  // Normalise playerIds from either route param or query param
+  const playerIds = useMemo(() => {
+    if (routeUserId) return [routeUserId];
+    return (searchParams.get('players') ?? '').split(',').filter(Boolean);
+  }, [routeUserId, searchParams]);
+
+  const isSinglePlayer = playerIds.length === 1;
+
+  const setPlayerIds = (ids: string[]) => {
+    navigate(`/pack/${packId}/compare?players=${ids.join(',')}`, { replace: !!routeUserId });
+  };
+
+  const [data, setData] = useState<PackPlayerScoresResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [lbUsers, setLbUsers] = useState<{ userId: string; alias: string; profileImageUrl: string | null }[]>([]);
+  const [pickerSearch, setPickerSearch] = useState('');
+  const [showPicker, setShowPicker] = useState(false);
+
+  useEffect(() => {
+    if (!packId) return;
+    getPack(parseInt(packId, 10))
+      .then((pack) => {
+        const lb = pack.packLeaderboard;
+        if (!lb) return;
+        const users = Object.entries(lb.users)
+          .map(([userId, info]) => ({ userId, alias: info.alias, profileImageUrl: info.profileImageUrl }))
+          .sort((a, b) => a.alias.localeCompare(b.alias));
+        setLbUsers(users);
+      })
+      .catch(() => {});
+  }, [packId]);
+
+  const playerIdsKey = playerIds.join(',');
+
+  useEffect(() => {
+    if (!packId || playerIds.length === 0) {
+      setData(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    getPackPlayerScores(packId, playerIds)
+      .then(setData)
+      .catch((err) => setError(err?.message ?? 'Failed to load scores'))
+      .finally(() => setLoading(false));
+  }, [packId, playerIdsKey]);
+
+  const handleRemovePlayer = (userId: string) => setPlayerIds(playerIds.filter((id) => id !== userId));
+  const handleAddPlayer = (userId: string) => {
+    if (playerIds.includes(userId)) return;
+    setPlayerIds([...playerIds, userId]);
+    setPickerSearch('');
+    setShowPicker(false);
+  };
+
+  const availablePlayers = lbUsers.filter(
+    (u) => !playerIds.includes(u.userId) && (!pickerSearch || u.alias.toLowerCase().includes(pickerSearch.toLowerCase())),
+  );
+
+  const singlePlayer = isSinglePlayer ? data?.players[0] : null;
+
+  if (playerIds.length === 0) {
+    return (
+      <AppPageLayout accent="secondary">
+        <div className="container mx-auto px-4 py-8 space-y-4 max-w-4xl">
+          <button onClick={() => navigate(`/pack/${packId}`)} className="btn btn-ghost btn-sm gap-1">
+            <ArrowLeft size={16} /> Back to Pack
+          </button>
+          <Alert variant="error">No players selected.</Alert>
+        </div>
+      </AppPageLayout>
+    );
+  }
+
+  return (
+    <AppPageLayout accent="secondary">
+      <div className="container mx-auto px-4 py-6 space-y-6 max-w-5xl">
+        {/* Back nav */}
+        <button onClick={() => navigate(`/pack/${packId}`)} className="btn btn-ghost btn-sm gap-1">
+          <ArrowLeft size={16} /> Back to Pack
+        </button>
+
+        {/* Single-player header card */}
+        {isSinglePlayer && singlePlayer && (
+          <div className="card bg-base-100/60 backdrop-blur-sm shadow-lg">
+            <div className="card-body">
+              <div className="flex items-center gap-4">
+                <ProfileAvatar profileImageUrl={singlePlayer.profileImageUrl} alias={singlePlayer.alias} size="xl" />
+                <div className="flex-1 min-w-0">
+                  <Link to={`/user/${singlePlayer.userId}`} className="text-2xl font-bold hover:text-primary transition-colors truncate block">
+                    {singlePlayer.alias}
+                  </Link>
+                  <div className="text-sm text-base-content/60 mt-0.5">Pack score summary</div>
+                </div>
+                <button onClick={() => setShowPicker((v) => !v)} className="btn btn-outline btn-sm gap-1 shrink-0">
+                  <Plus size={14} /> Compare
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Multi-player: player chips */}
+        {!isSinglePlayer && (
+          <div className="card bg-base-100/60 backdrop-blur-sm shadow-lg">
+            <div className="card-body py-4">
+              <div className="flex flex-wrap items-center gap-2">
+                {(data?.players ?? []).map((p) => (
+                  <div key={p.userId} className="flex items-center gap-1.5 bg-base-200/80 rounded-full pl-1 pr-2 py-1">
+                    <ProfileAvatar profileImageUrl={p.profileImageUrl} alias={p.alias} size="sm" />
+                    <Link to={`/pack/${packId}/player/${p.userId}`} className="text-sm font-medium hover:text-primary transition-colors">
+                      {p.alias}
+                    </Link>
+                    <button onClick={() => handleRemovePlayer(p.userId)} className="btn btn-ghost btn-xs btn-circle ml-0.5">
+                      <X size={12} />
+                    </button>
+                  </div>
+                ))}
+                {playerIds
+                  .filter((id) => !data?.players.find((p) => p.userId === id))
+                  .map((id) => (
+                    <div key={id} className="flex items-center gap-1.5 bg-base-200/50 rounded-full px-3 py-1 opacity-50">
+                      <span className="text-xs">Loading…</span>
+                      <button onClick={() => handleRemovePlayer(id)} className="btn btn-ghost btn-xs btn-circle">
+                        <X size={12} />
+                      </button>
+                    </div>
+                  ))}
+                <button onClick={() => setShowPicker((v) => !v)} className="btn btn-outline btn-sm gap-1">
+                  <Plus size={14} /> Add player
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Player picker dropdown (shown as overlay below header) */}
+        {showPicker && (
+          <div className="card bg-base-200 shadow-xl border border-base-300">
+            <div className="card-body py-3 px-3 space-y-2">
+              <input
+                autoFocus
+                type="text"
+                placeholder="Search players…"
+                value={pickerSearch}
+                onChange={(e) => setPickerSearch(e.target.value)}
+                className="input input-bordered input-sm w-full"
+              />
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-1 max-h-48 overflow-y-auto">
+                {availablePlayers.length === 0 ? (
+                  <div className="col-span-full text-sm text-base-content/50 py-3 text-center">No players found</div>
+                ) : (
+                  availablePlayers.map((u) => (
+                    <button
+                      key={u.userId}
+                      onClick={() => handleAddPlayer(u.userId)}
+                      className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-base-300/60 transition-colors text-left"
+                    >
+                      <ProfileAvatar profileImageUrl={u.profileImageUrl} alias={u.alias} size="sm" />
+                      <span className="text-sm truncate">{u.alias}</span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Leaderboard toggle */}
+        <LeaderboardToggle options={['HardEX', 'EX', 'ITG']} />
+
+        {loading && (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 size={40} className="text-primary animate-spin" />
+          </div>
+        )}
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        {!loading && data && data.players.length > 0 && (
+          <div className="card bg-base-100/60 backdrop-blur-sm shadow-lg overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="table table-sm [&_tr]:!bg-transparent">
+                <thead>
+                  <tr>
+                    <th className="bg-base-200/50 font-semibold text-base-content text-left min-w-52">Song</th>
+                    {!isSinglePlayer && <th className="bg-base-200/50 font-semibold text-base-content text-left w-px whitespace-nowrap">Player</th>}
+                    {DIFFICULTY_COLS.map(({ key, label }) => (
+                      <th key={key} className="bg-base-200/50 font-semibold text-base-content text-center w-36">
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                {data.simfiles.map((sf, sfIdx) => (
+                  <tbody key={sf.simfileId} className={sfIdx % 2 === 1 ? 'bg-base-content/[0.025]' : ''}>
+                    {data.players.map((player, playerIdx) => (
+                      <tr key={`${sf.simfileId}-${player.userId}`} className={playerIdx === 0 && sfIdx > 0 ? 'border-t border-base-content/5' : ''}>
+                        {/* Song column: only on first player row, spans all */}
+                        {playerIdx === 0 && (
+                          <td rowSpan={data.players.length} className="py-2 pr-4 align-middle">
+                            <div className="flex items-center gap-3 min-w-0">
+                              <div className="shrink-0 rounded overflow-hidden shadow-sm" style={{ width: 100, aspectRatio: '2.56' }}>
+                                <BannerImage
+                                  bannerUrl={sf.bannerUrl}
+                                  mdBannerUrl={sf.mdBannerUrl}
+                                  smBannerUrl={sf.smBannerUrl}
+                                  bannerVariants={sf.bannerVariants}
+                                  alt={sf.title}
+                                  className="w-full h-full object-cover"
+                                  iconSize={14}
+                                />
+                              </div>
+                              <div className="min-w-0">
+                                <div className="font-medium text-base-content text-sm truncate">{sf.title}</div>
+                                {sf.artist && <div className="text-xs text-base-content/60 truncate">{sf.artist}</div>}
+                              </div>
+                            </div>
+                          </td>
+                        )}
+                        {/* Player column (multi only) */}
+                        {!isSinglePlayer && (
+                          <td className="py-2 px-2 align-middle border-l border-base-content/10 w-px whitespace-nowrap">
+                            <Link to={`/pack/${packId}/player/${player.userId}`} className="hover:opacity-80 transition-opacity">
+                              {player.profileImageUrl ? (
+                                <ProfileAvatar profileImageUrl={player.profileImageUrl} alias={player.alias} size="sm" />
+                              ) : (
+                                <span className="text-sm font-medium hover:text-primary transition-colors">{player.alias}</span>
+                              )}
+                            </Link>
+                          </td>
+                        )}
+                        {/* Score cells */}
+                        {DIFFICULTY_COLS.map(({ key }) => (
+                          <ScoreCell
+                            key={key}
+                            player={player}
+                            simfile={sf}
+                            diffKey={key}
+                            lbKey={activeLeaderboard}
+                            ctx={
+                              isSinglePlayer ? { state: 'none', diff: null } : getScoreContext(data.players, player, sf.charts[key]?.hash, activeLeaderboard)
+                            }
+                          />
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                ))}
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppPageLayout>
+  );
+};

--- a/frontend/src/pages/profile/components/WidgetSection.tsx
+++ b/frontend/src/pages/profile/components/WidgetSection.tsx
@@ -1,5 +1,5 @@
+/* eslint-disable formatjs/no-literal-string-in-jsx */
 import React, { useState, useEffect, useRef } from 'react';
-import { useIntl } from 'react-intl';
 import { useAuth } from '../../../contexts/AuthContext';
 import { listPacks } from '../../../services/api';
 import type { PackListItem } from '../../../schemas/apiSchemas';
@@ -12,7 +12,19 @@ import {
   type LeaderboardKey,
   type PackLeaderboardDifficulty,
 } from '../../../utils/widgetConfig';
-import { ChevronUp, ChevronDown, X, Plus } from 'lucide-react';
+import { ChevronUp, ChevronDown, X, Plus, Check, ArrowRight, ArrowLeft, Copy, CheckCheck } from 'lucide-react';
+
+const WIGGLE_KEYFRAMES = `
+  @keyframes dimWiggle {
+    0%, 100% { transform: rotate(0deg) translateY(0); }
+    15%  { transform: rotate(-5deg) translateY(-3px); }
+    30%  { transform: rotate(5deg)  translateY(-3px); }
+    45%  { transform: rotate(-4deg) translateY(-2px); }
+    60%  { transform: rotate(4deg)  translateY(-2px); }
+    75%  { transform: rotate(-2deg) translateY(-1px); }
+    90%  { transform: rotate(1deg)  translateY(0); }
+  }
+`;
 
 const AVAILABLE_THEMES = [
   { id: 'arrow-blue', label: 'Arrow Blue (Default)' },
@@ -40,8 +52,13 @@ const AVAILABLE_THEMES = [
 const LB_LABELS: Record<LeaderboardKey, string> = { HardEX: 'H.EX', EX: 'EX', ITG: 'ITG' };
 const ALL_LB_KEYS: LeaderboardKey[] = ['HardEX', 'EX', 'ITG'];
 const DIFF_LABELS: Record<PackLeaderboardDifficulty, string> = { medium: 'Medium', hard: 'Hard', challenge: 'Challenge' };
-
 const LB_ID_MAP: Record<number, LeaderboardKey> = { 4: 'HardEX', 2: 'EX', 3: 'ITG' };
+
+const FEATURE_DESCRIPTIONS: Record<WidgetFeatureConfig['type'], string> = {
+  recentPlays: 'Cycles through your 3 most recent scores',
+  packLeaderboard: 'Shows your rank in a specific pack',
+  currentSession: 'Live session timer with play count, charts, and steps hit',
+};
 
 function getDefaultLeaderboards(user: any): LeaderboardKey[] {
   const prefs: number[] = user?.preferredLeaderboards ?? [];
@@ -54,13 +71,70 @@ function bestBannerUrl(pack: PackListItem): string | null {
 }
 
 function featureLabel(f: WidgetFeatureConfig): string {
-  if (f.type === 'profile') return 'Profile';
   if (f.type === 'recentPlays') return 'Recent Plays';
   if (f.type === 'packLeaderboard') return `Pack Leaderboard — ${f.packName || f.packId}`;
+  if (f.type === 'currentSession') return 'Current Session';
   return 'Unknown';
 }
 
-// ---- Feature card sub-components ----
+// ---- Step indicator ----
+
+type WizardStep = 1 | 2 | 3 | 4;
+const STEP_LABELS: Record<WizardStep, string> = { 1: 'Layout', 2: 'Features', 3: 'Appearance', 4: 'Setup Stream' };
+
+const StepIndicator: React.FC<{ current: WizardStep; onGoTo: (s: WizardStep) => void }> = ({ current, onGoTo }) => (
+  <div className="flex items-center mb-6">
+    {([1, 2, 3, 4] as WizardStep[]).map((s, i) => (
+      <React.Fragment key={s}>
+        <button
+          type="button"
+          onClick={() => s < current && onGoTo(s)}
+          className={`flex items-center gap-1.5 ${s < current ? 'cursor-pointer' : 'cursor-default'}`}
+        >
+          <div
+            className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 transition ${
+              s < current
+                ? 'bg-primary text-primary-content'
+                : s === current
+                  ? 'border-2 border-primary text-primary'
+                  : 'border-2 border-base-300 text-base-content/40'
+            }`}
+          >
+            {s < current ? <Check className="w-3.5 h-3.5" /> : s}
+          </div>
+          <span
+            className={`text-xs font-medium hidden sm:block ${s === current ? 'text-base-content' : s < current ? 'text-primary' : 'text-base-content/40'}`}
+          >
+            {STEP_LABELS[s]}
+          </span>
+        </button>
+        {i < 3 && <div className="flex-1 h-px mx-2 bg-base-300/60" />}
+      </React.Fragment>
+    ))}
+  </div>
+);
+
+// ---- Preview block ----
+
+const WidgetPreview: React.FC<{ url: string; width: number; height: number }> = ({ url, width, height }) => (
+  <div>
+    <div className="text-sm font-semibold text-base-content mb-2">Preview</div>
+    {/* Dark background simulates an OBS scene — transparent areas of the widget show through */}
+    <div
+      className="rounded-lg p-4 flex items-center justify-center overflow-auto min-h-[100px]"
+      style={{
+        background: '#0f172a',
+        backgroundImage: 'linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px)',
+        backgroundSize: '24px 24px',
+      }}
+    >
+      {/* allowTransparency sets the iframe's BaseBackgroundColor to alpha-0 so the dark grid shows through transparent areas */}
+      <iframe allowTransparency src={url} width={width} height={height} className="border-0 block" style={{ backgroundColor: 'transparent' }} />
+    </div>
+  </div>
+);
+
+// ---- Shared sub-components ----
 
 const LeaderboardCheckboxes: React.FC<{
   selected: LeaderboardKey[];
@@ -79,7 +153,7 @@ const LeaderboardCheckboxes: React.FC<{
             className="hidden"
             checked={checked}
             onChange={() => {
-              if (checked && selected.length === 1) return; // keep at least 1
+              if (checked && selected.length === 1) return;
               onChange(checked ? selected.filter((k) => k !== key) : [...selected, key]);
             }}
           />
@@ -94,70 +168,56 @@ const PackLeaderboardConfig: React.FC<{
   feature: Extract<WidgetFeatureConfig, { type: 'packLeaderboard' }>;
   packs: PackListItem[];
   onChange: (f: Extract<WidgetFeatureConfig, { type: 'packLeaderboard' }>) => void;
-}> = ({ feature, packs, onChange }) => {
-  const intl = useIntl();
-  return (
-    <div className="space-y-3 mt-2">
-      <div>
-        <label className="text-xs font-semibold text-base-content/70 mb-1 block">
-          {intl.formatMessage({ id: 'mFmFwY', defaultMessage: 'Pack', description: 'Pack select label in widget config' })}
-        </label>
-        <select
-          className="select select-sm select-bordered w-full"
-          value={feature.packId}
-          onChange={(e) => {
-            const pack = packs.find((p) => p.id === parseInt(e.target.value, 10));
-            if (pack) onChange({ ...feature, packId: pack.id, packName: pack.name, bannerUrl: bestBannerUrl(pack) });
-          }}
-        >
-          {packs.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.name}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div>
-        <label className="text-xs font-semibold text-base-content/70 mb-1 block">
-          {intl.formatMessage({ id: 'Ju1dPo', defaultMessage: 'Difficulty', description: 'Difficulty select label in widget config' })}
-        </label>
-        <div className="flex gap-2">
-          {(['medium', 'hard', 'challenge'] as PackLeaderboardDifficulty[]).map((d) => (
-            <button
-              key={d}
-              type="button"
-              className={`btn btn-xs ${feature.difficulty === d ? 'btn-primary' : 'btn-outline'}`}
-              onClick={() => onChange({ ...feature, difficulty: d })}
-            >
-              {DIFF_LABELS[d]}
-            </button>
-          ))}
-        </div>
-      </div>
-      <div>
-        <label className="text-xs font-semibold text-base-content/70 mb-1 block">
-          {intl.formatMessage({ id: 'RCi2iU', defaultMessage: 'Scoring Systems', description: 'Scoring systems label in widget pack leaderboard config' })}
-        </label>
-        <LeaderboardCheckboxes selected={feature.leaderboards} onChange={(keys) => onChange({ ...feature, leaderboards: keys })} />
+}> = ({ feature, packs, onChange }) => (
+  <div className="space-y-3 mt-2">
+    <div>
+      <label className="text-xs font-semibold text-base-content/70 mb-1 block">Pack</label>
+      <select
+        className="select select-sm select-bordered w-full"
+        value={feature.packId}
+        onChange={(e) => {
+          const pack = packs.find((p) => p.id === parseInt(e.target.value, 10));
+          if (pack) onChange({ ...feature, packId: pack.id, packName: pack.name, bannerUrl: bestBannerUrl(pack) });
+        }}
+      >
+        {packs.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+    </div>
+    <div>
+      <label className="text-xs font-semibold text-base-content/70 mb-1 block">Difficulty</label>
+      <div className="flex gap-2">
+        {(['medium', 'hard', 'challenge'] as PackLeaderboardDifficulty[]).map((d) => (
+          <button
+            key={d}
+            type="button"
+            className={`btn btn-xs ${feature.difficulty === d ? 'btn-primary' : 'btn-outline'}`}
+            onClick={() => onChange({ ...feature, difficulty: d })}
+          >
+            {DIFF_LABELS[d]}
+          </button>
+        ))}
       </div>
     </div>
-  );
-};
+    <div>
+      <label className="text-xs font-semibold text-base-content/70 mb-1 block">Scoring Systems</label>
+      <LeaderboardCheckboxes selected={feature.leaderboards} onChange={(keys) => onChange({ ...feature, leaderboards: keys })} />
+    </div>
+  </div>
+);
 
 const RecentPlaysConfig: React.FC<{
   feature: Extract<WidgetFeatureConfig, { type: 'recentPlays' }>;
   onChange: (f: Extract<WidgetFeatureConfig, { type: 'recentPlays' }>) => void;
-}> = ({ feature, onChange }) => {
-  const intl = useIntl();
-  return (
-    <div className="mt-2">
-      <label className="text-xs font-semibold text-base-content/70 mb-1 block">
-        {intl.formatMessage({ id: 'r8saR8', defaultMessage: 'Scoring Systems', description: 'Scoring systems label in widget recent plays config' })}
-      </label>
-      <LeaderboardCheckboxes selected={feature.leaderboards} onChange={(keys) => onChange({ ...feature, leaderboards: keys })} />
-    </div>
-  );
-};
+}> = ({ feature, onChange }) => (
+  <div className="mt-2">
+    <label className="text-xs font-semibold text-base-content/70 mb-1 block">Scoring Systems</label>
+    <LeaderboardCheckboxes selected={feature.leaderboards} onChange={(keys) => onChange({ ...feature, leaderboards: keys })} />
+  </div>
+);
 
 interface FeatureCardProps {
   feature: WidgetFeatureConfig;
@@ -171,37 +231,31 @@ interface FeatureCardProps {
 }
 
 const FeatureCard: React.FC<FeatureCardProps> = ({ feature, index, total, packs, onMoveUp, onMoveDown, onRemove, onChange }) => {
-  const intl = useIntl();
-  const hasConfig = feature.type !== 'profile';
-  const [expanded, setExpanded] = useState(hasConfig);
+  const [expanded, setExpanded] = useState(true);
 
   return (
     <div className="border border-base-300/50 rounded-lg bg-base-200/40">
       <div className="flex items-center gap-2 p-3">
-        <button type="button" className="flex-1 text-left text-sm font-medium" onClick={() => hasConfig && setExpanded((e) => !e)}>
-          <span className="text-base-content/50 mr-2 text-xs">
-            {intl.formatMessage({ id: 'uj5W+N', defaultMessage: '#{rank}', description: 'Feature position indicator' }, { rank: index + 1 })}
-          </span>
+        <button type="button" className="flex-1 text-left text-sm font-medium" onClick={() => setExpanded((e) => !e)}>
+          <span className="text-base-content/50 mr-2 text-xs">#{index + 1}</span>
           {featureLabel(feature)}
-          {hasConfig && (
-            <span className="ml-2 text-xs text-base-content/40">
-              {expanded ? <ChevronUp className="w-3 h-3 inline" /> : <ChevronDown className="w-3 h-3 inline" />}
-            </span>
-          )}
+          <span className="ml-2 text-xs text-base-content/40">
+            {expanded ? <ChevronUp className="w-3 h-3 inline" /> : <ChevronDown className="w-3 h-3 inline" />}
+          </span>
         </button>
         <div className="flex items-center gap-1">
-          <button type="button" className="btn btn-ghost btn-xs" onClick={onMoveUp} disabled={index === 0}>
-            <ChevronUp className="w-3 h-3" />
+          <button type="button" className="btn btn-ghost btn-sm" onClick={onMoveUp} disabled={index === 0}>
+            <ChevronUp className="w-4 h-4" />
           </button>
-          <button type="button" className="btn btn-ghost btn-xs" onClick={onMoveDown} disabled={index === total - 1}>
-            <ChevronDown className="w-3 h-3" />
+          <button type="button" className="btn btn-ghost btn-sm" onClick={onMoveDown} disabled={index === total - 1}>
+            <ChevronDown className="w-4 h-4" />
           </button>
-          <button type="button" className="btn btn-ghost btn-xs text-error" onClick={onRemove}>
-            <X className="w-3 h-3" />
+          <button type="button" className="btn btn-ghost btn-sm text-error hover:bg-error/10" onClick={onRemove}>
+            <X className="w-4 h-4" />
           </button>
         </div>
       </div>
-      {expanded && hasConfig && (
+      {expanded && (feature.type === 'recentPlays' || feature.type === 'packLeaderboard') && (
         <div className="px-3 pb-3 border-t border-base-300/30 pt-2">
           {feature.type === 'recentPlays' && <RecentPlaysConfig feature={feature} onChange={(f) => onChange(f)} />}
           {feature.type === 'packLeaderboard' && <PackLeaderboardConfig feature={feature} packs={packs} onChange={(f) => onChange(f)} />}
@@ -211,33 +265,452 @@ const FeatureCard: React.FC<FeatureCardProps> = ({ feature, index, total, packs,
   );
 };
 
-// ---- Main wizard component ----
+// ---- Dimension speech bubble with wiggle ----
 
-export const WidgetSection: React.FC = () => {
-  const { user } = useAuth();
-  const intl = useIntl();
-  const [selectedTheme, setSelectedTheme] = useState('arrow-blue');
-  const [compatMode, setCompatMode] = useState(false);
-  const [copied, setCopied] = useState(false);
+const DimensionBubble: React.FC<{ width: number; height: number; postCopy?: boolean }> = ({ width, height, postCopy }) => {
+  const [wiggleCount, setWiggleCount] = useState(0);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    if (wiggleCount >= 5) return;
+    const delay = wiggleCount === 0 ? 800 : 3000;
+    const t = setTimeout(() => setAnimating(true), delay);
+    return () => clearTimeout(t);
+  }, [wiggleCount]);
+
+  return (
+    <>
+      <style>{WIGGLE_KEYFRAMES}</style>
+      <div className="flex items-start gap-3">
+        {/* Bubble + pointer */}
+        <div className="relative flex-shrink-0 mt-0.5">
+          <div
+            className="bg-warning text-warning-content text-xs font-bold px-3 py-2 rounded-xl shadow-lg whitespace-nowrap leading-snug"
+            style={animating ? { animation: 'dimWiggle 0.7s ease-in-out' } : undefined}
+            onAnimationEnd={() => {
+              setAnimating(false);
+              setWiggleCount((c) => c + 1);
+            }}
+          >
+            {postCopy ? (
+              <>
+                <div>Don't forget these —</div>
+                <div>or it won't fit!</div>
+              </>
+            ) : (
+              <>
+                <div>Set these exact</div>
+                <div>values in OBS!</div>
+              </>
+            )}
+            {/* Tail pointing right */}
+            <span
+              className="absolute top-1/2 -translate-y-1/2 left-full"
+              style={{
+                width: 0,
+                height: 0,
+                borderTop: '6px solid transparent',
+                borderBottom: '6px solid transparent',
+                borderLeft: '8px solid oklch(var(--wa))',
+              }}
+            />
+          </div>
+        </div>
+        {/* Dimension values */}
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-base-content/60 w-12">Width</span>
+            <span className="font-mono font-bold bg-base-300 px-2.5 py-0.5 rounded-md text-base-content">{width}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-base-content/60 w-12">Height</span>
+            <span className="font-mono font-bold bg-base-300 px-2.5 py-0.5 rounded-md text-base-content">{height}</span>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+// ---- Step 1: Layout ----
+
+const LayoutStep: React.FC<{
+  orientation: 'horizontal' | 'vertical';
+  setOrientation: (o: 'horizontal' | 'vertical') => void;
+  onNext: () => void;
+}> = ({ orientation, setOrientation, onNext }) => (
+  <div className="space-y-6">
+    <div>
+      <div className="text-sm font-semibold text-base-content mb-3">Layout</div>
+      <div className="grid grid-cols-2 gap-3">
+        {(['horizontal', 'vertical'] as const).map((o) => {
+          const isActive = orientation === o;
+          return (
+            <button
+              key={o}
+              type="button"
+              onClick={() => setOrientation(o)}
+              className={`border-2 rounded-xl p-4 flex flex-col items-center gap-3 transition ${isActive ? 'border-primary bg-primary/5' : 'border-base-300/50 hover:border-base-300 bg-base-200/30'}`}
+            >
+              {o === 'horizontal' ? (
+                <div className="flex flex-col gap-1 h-14 w-28">
+                  {/* Profile bar */}
+                  <div className={`h-3 rounded ${isActive ? 'bg-primary/60' : 'bg-base-300'}`} />
+                  {/* Feature panels side by side */}
+                  <div className="flex gap-1 flex-1">
+                    <div className={`flex-1 rounded ${isActive ? 'bg-primary/25' : 'bg-base-300/70'}`} />
+                    <div className={`flex-1 rounded ${isActive ? 'bg-primary/20' : 'bg-base-300/50'}`} />
+                  </div>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-1 w-20 h-14">
+                  {/* Profile bar */}
+                  <div className={`h-3 rounded ${isActive ? 'bg-primary/60' : 'bg-base-300'}`} />
+                  {/* Stacked panels */}
+                  <div className={`flex-1 rounded ${isActive ? 'bg-primary/25' : 'bg-base-300/70'}`} />
+                  <div className={`h-4 rounded ${isActive ? 'bg-primary/20' : 'bg-base-300/50'}`} />
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center ${isActive ? 'border-primary bg-primary' : 'border-base-300'}`}>
+                  {isActive && <Check className="w-2.5 h-2.5 text-primary-content" />}
+                </div>
+                <span className={`text-sm font-medium ${isActive ? 'text-primary' : 'text-base-content'}`}>
+                  {o === 'horizontal' ? 'Horizontal' : 'Vertical'}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-xs text-base-content/50 mt-2">
+        {orientation === 'horizontal'
+          ? 'Your profile above, panels side by side below — best for a corner overlay'
+          : 'Your profile above, panels stacked below — best for a sidebar overlay'}
+      </p>
+    </div>
+
+    <div className="flex justify-end pt-2">
+      <button type="button" className="btn btn-primary gap-2" onClick={onNext}>
+        Next: Add Features
+        <ArrowRight className="w-4 h-4" />
+      </button>
+    </div>
+  </div>
+);
+
+// ---- Step 2: Features ----
+
+const FeaturesStep: React.FC<{
+  features: WidgetFeatureConfig[];
+  setFeatures: (f: WidgetFeatureConfig[]) => void;
+  packs: PackListItem[];
+  user: any;
+  previewUrl: string;
+  widgetWidth: number;
+  widgetHeight: number;
+  onBack: () => void;
+  onNext: () => void;
+}> = ({ features, setFeatures, packs, user, previewUrl, widgetWidth, widgetHeight, onBack, onNext }) => {
   const [showAddMenu, setShowAddMenu] = useState(false);
   const addMenuRef = useRef<HTMLDivElement>(null);
 
-  const [features, setFeatures] = useState<WidgetFeatureConfig[]>([{ type: 'profile' }]);
-  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>('horizontal');
-  const [packs, setPacks] = useState<PackListItem[]>([]);
-
-  // Close add menu on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
-        setShowAddMenu(false);
-      }
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) setShowAddMenu(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
-  // Load eligible packs once, filtering to known eligible IDs client-side as a safety net
+  const featureCount = features.length;
+  const hasRecentPlays = features.some((f) => f.type === 'recentPlays');
+  const hasCurrentSession = features.some((f) => f.type === 'currentSession');
+  const defaultPack = packs[0];
+
+  const moveUp = (i: number) => {
+    if (i === 0) return;
+    const next = [...features];
+    [next[i - 1], next[i]] = [next[i], next[i - 1]];
+    setFeatures(next);
+  };
+
+  const moveDown = (i: number) => {
+    if (i === featureCount - 1) return;
+    const next = [...features];
+    [next[i], next[i + 1]] = [next[i + 1], next[i]];
+    setFeatures(next);
+  };
+
+  const removeFeature = (i: number) => setFeatures(features.filter((_, idx) => idx !== i));
+
+  const updateFeature = (i: number, f: WidgetFeatureConfig) => {
+    const next = [...features];
+    next[i] = f;
+    setFeatures(next);
+  };
+
+  const addFeature = (f: WidgetFeatureConfig) => {
+    if (featureCount >= 5) return;
+    setFeatures([...features, f]);
+    setShowAddMenu(false);
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Feature list */}
+      <div className="space-y-2">
+        {features.map((f, i) => (
+          <FeatureCard
+            key={i}
+            feature={f}
+            index={i}
+            total={featureCount}
+            packs={packs}
+            onMoveUp={() => moveUp(i)}
+            onMoveDown={() => moveDown(i)}
+            onRemove={() => removeFeature(i)}
+            onChange={(updated) => updateFeature(i, updated)}
+          />
+        ))}
+        {features.length === 0 && (
+          <div className="text-sm text-base-content/50 border border-dashed border-base-300 rounded-lg p-4 text-center">
+            No features added yet — use the button below to get started.
+          </div>
+        )}
+      </div>
+
+      {/* Add feature button — prominent, above preview */}
+      {featureCount < 5 ? (
+        <div className="relative" ref={addMenuRef}>
+          <button type="button" className="btn btn-secondary w-full gap-2 shadow-md" onClick={() => setShowAddMenu((v) => !v)}>
+            <Plus className="w-4 h-4" />
+            Add a Feature
+          </button>
+          {showAddMenu && (
+            <div className="absolute top-full left-0 right-0 mt-1 bg-base-100 border border-base-300 rounded-lg shadow-xl z-10 py-1">
+              <button
+                type="button"
+                className={`w-full text-left px-4 py-2.5 text-sm hover:bg-base-200 transition ${hasRecentPlays ? 'opacity-40 cursor-not-allowed' : ''}`}
+                onClick={() => !hasRecentPlays && addFeature({ type: 'recentPlays', leaderboards: getDefaultLeaderboards(user) })}
+              >
+                <div className="font-medium">Recent Plays</div>
+                <div className="text-xs text-base-content/50">{FEATURE_DESCRIPTIONS.recentPlays}</div>
+                {hasRecentPlays && <div className="text-xs text-warning mt-0.5">Already added</div>}
+              </button>
+              <button
+                type="button"
+                className={`w-full text-left px-4 py-2.5 text-sm hover:bg-base-200 transition ${!defaultPack ? 'opacity-40 cursor-not-allowed' : ''}`}
+                onClick={() =>
+                  defaultPack &&
+                  addFeature({
+                    type: 'packLeaderboard',
+                    packId: defaultPack.id,
+                    packName: defaultPack.name,
+                    bannerUrl: bestBannerUrl(defaultPack),
+                    difficulty: 'challenge',
+                    leaderboards: getDefaultLeaderboards(user),
+                  })
+                }
+              >
+                <div className="font-medium">Pack Leaderboard</div>
+                <div className="text-xs text-base-content/50">{FEATURE_DESCRIPTIONS.packLeaderboard}</div>
+                {!defaultPack && <div className="text-xs text-base-content/40 mt-0.5">No eligible packs available</div>}
+              </button>
+              <button
+                type="button"
+                className={`w-full text-left px-4 py-2.5 text-sm hover:bg-base-200 transition ${hasCurrentSession ? 'opacity-40 cursor-not-allowed' : ''}`}
+                onClick={() => !hasCurrentSession && addFeature({ type: 'currentSession' })}
+              >
+                <div className="font-medium">Current Session</div>
+                <div className="text-xs text-base-content/50">{FEATURE_DESCRIPTIONS.currentSession}</div>
+                {hasCurrentSession && <div className="text-xs text-warning mt-0.5">Already added</div>}
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="text-xs text-base-content/50">Maximum of 5 features reached.</p>
+      )}
+
+      {/* Live preview */}
+      {features.length > 0 && <WidgetPreview url={previewUrl} width={widgetWidth} height={widgetHeight} />}
+
+      <div className="flex justify-between pt-2">
+        <button type="button" className="btn btn-ghost gap-2" onClick={onBack}>
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+        <button type="button" className="btn btn-primary gap-2" onClick={onNext} disabled={features.length === 0}>
+          Next: Appearance
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ---- Step 3: Appearance ----
+
+const AppearanceStep: React.FC<{
+  selectedTheme: string;
+  setSelectedTheme: (t: string) => void;
+  compatMode: boolean;
+  previewUrl: string;
+  widgetWidth: number;
+  widgetHeight: number;
+  onBack: () => void;
+  onNext: () => void;
+}> = ({ selectedTheme, setSelectedTheme, compatMode, previewUrl, widgetWidth, widgetHeight, onBack, onNext }) => (
+  <div className="space-y-5">
+    <WidgetPreview url={previewUrl} width={widgetWidth} height={widgetHeight} />
+
+    <div>
+      <label className="text-sm font-semibold text-base-content block mb-2">Theme</label>
+      <select className="select select-bordered w-full" value={selectedTheme} onChange={(e) => setSelectedTheme(e.target.value)} disabled={compatMode}>
+        {AVAILABLE_THEMES.map((t) => (
+          <option key={t.id} value={t.id}>
+            {t.label}
+          </option>
+        ))}
+      </select>
+      {compatMode ? (
+        <p className="text-xs text-base-content/50 mt-1">Theme is disabled in compatibility mode (set in Setup Stream)</p>
+      ) : (
+        <p className="text-xs text-base-content/50 mt-1">Light themes may show a white background in this preview — they display correctly in OBS.</p>
+      )}
+    </div>
+
+    <div className="flex justify-between pt-2">
+      <button type="button" className="btn btn-ghost gap-2" onClick={onBack}>
+        <ArrowLeft className="w-4 h-4" />
+        Back
+      </button>
+      <button type="button" className="btn btn-primary gap-2" onClick={onNext}>
+        Next: Setup Stream
+        <ArrowRight className="w-4 h-4" />
+      </button>
+    </div>
+  </div>
+);
+
+// ---- Step 4: Setup Stream ----
+
+const SetupStreamStep: React.FC<{
+  widgetUrl: string;
+  widgetWidth: number;
+  widgetHeight: number;
+  compatMode: boolean;
+  setCompatMode: (v: boolean) => void;
+  previewUrl: string;
+  onBack: () => void;
+}> = ({ widgetUrl, widgetWidth, widgetHeight, compatMode, setCompatMode, previewUrl, onBack }) => {
+  const [copied, setCopied] = useState(false);
+  const [hasCopied, setHasCopied] = useState(false);
+  const [bubbleKey, setBubbleKey] = useState(0);
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(widgetUrl);
+    setCopied(true);
+    setHasCopied(true);
+    setBubbleKey((k) => k + 1);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-6">
+      <WidgetPreview url={previewUrl} width={widgetWidth} height={widgetHeight} />
+
+      {/* Compat mode */}
+      <div className="border border-base-300/40 rounded-lg p-3 bg-base-200/30">
+        <label className="flex items-start gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            className="checkbox checkbox-sm checkbox-primary mt-0.5"
+            checked={compatMode}
+            onChange={(e) => setCompatMode(e.target.checked)}
+          />
+          <div>
+            <div className="text-sm font-medium">Compatibility Mode</div>
+            <div className="text-xs text-base-content/60 mt-0.5">
+              Use if OBS Studio &lt; v31 or using Streamlabs. Themes will be disabled and replaced with a built-in dark style.
+            </div>
+          </div>
+        </label>
+      </div>
+
+      {/* OBS Steps */}
+      <div>
+        <div className="text-sm font-semibold text-base-content mb-3">Add to OBS Studio</div>
+        <ol className="space-y-5">
+          <li className="flex gap-3">
+            <div className="w-6 h-6 rounded-full bg-primary text-primary-content text-xs font-bold flex items-center justify-center flex-shrink-0 mt-0.5">
+              1
+            </div>
+            <div>
+              <div className="text-sm font-medium">Add a Browser Source</div>
+              <div className="text-xs text-base-content/60 mt-0.5">
+                In OBS, click <strong>+</strong> in the Sources panel → select <strong>Browser</strong>
+              </div>
+            </div>
+          </li>
+          <li className="flex gap-3">
+            <div className="w-6 h-6 rounded-full bg-primary text-primary-content text-xs font-bold flex items-center justify-center flex-shrink-0 mt-0.5">
+              2
+            </div>
+            <div className="flex-1">
+              <div className="text-sm font-medium mb-1.5">Paste the URL</div>
+              <div className="flex gap-2">
+                <input type="text" value={widgetUrl} readOnly className="input input-sm input-bordered flex-1 font-mono text-xs" />
+                <button className="btn btn-sm btn-primary flex-shrink-0 gap-1.5" onClick={copyToClipboard}>
+                  {copied ? (
+                    <>
+                      <CheckCheck className="w-3.5 h-3.5" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="w-3.5 h-3.5" />
+                      Copy
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+          </li>
+          <li className="flex gap-3">
+            <div className="w-6 h-6 rounded-full bg-primary text-primary-content text-xs font-bold flex items-center justify-center flex-shrink-0 mt-0.5">
+              3
+            </div>
+            <div>
+              <div className="text-sm font-medium mb-2">Set the dimensions</div>
+              <DimensionBubble key={bubbleKey} width={widgetWidth} height={widgetHeight} postCopy={hasCopied} />
+            </div>
+          </li>
+        </ol>
+      </div>
+
+      <div className="flex justify-between pt-2">
+        <button type="button" className="btn btn-ghost gap-2" onClick={onBack}>
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ---- Main component ----
+
+export const WidgetSection: React.FC = () => {
+  const { user } = useAuth();
+  const [step, setStep] = useState<WizardStep>(1);
+  const [selectedTheme, setSelectedTheme] = useState('arrow-blue');
+  const [compatMode, setCompatMode] = useState(false);
+  const [features, setFeatures] = useState<WidgetFeatureConfig[]>([{ type: 'currentSession' }, { type: 'recentPlays', leaderboards: ['EX'] }]);
+  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>('horizontal');
+  const [packs, setPacks] = useState<PackListItem[]>([]);
+
   useEffect(() => {
     listPacks({ eligibleOnly: true, limit: 100 })
       .then((res) => setPacks(res.data.filter((p) => ELIGIBLE_PACK_IDS.includes(p.id))))
@@ -255,251 +728,47 @@ export const WidgetSection: React.FC = () => {
   if (compatMode) params.set('compat', 'true');
   const widgetUrl = `${window.location.origin}/widget/streamer?${params.toString()}`;
 
-  const hasProfile = features.some((f) => f.type === 'profile');
-  const hasRecentPlays = features.some((f) => f.type === 'recentPlays');
-  const featureCount = features.length;
-
-  const moveUp = (i: number) => {
-    if (i === 0) return;
-    const next = [...features];
-    [next[i - 1], next[i]] = [next[i], next[i - 1]];
-    setFeatures(next);
-  };
-
-  const moveDown = (i: number) => {
-    if (i === featureCount - 1) return;
-    const next = [...features];
-    [next[i], next[i + 1]] = [next[i + 1], next[i]];
-    setFeatures(next);
-  };
-
-  const removeFeature = (i: number) => {
-    setFeatures(features.filter((_, idx) => idx !== i));
-  };
-
-  const updateFeature = (i: number, f: WidgetFeatureConfig) => {
-    const next = [...features];
-    next[i] = f;
-    setFeatures(next);
-  };
-
-  const addFeature = (f: WidgetFeatureConfig) => {
-    if (featureCount >= 5) return;
-    setFeatures([...features, f]);
-    setShowAddMenu(false);
-  };
-
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(widgetUrl);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  const defaultPack = packs[0];
-
   return (
-    <div className="space-y-6">
-      {/* Global Settings */}
-      <div className="space-y-4">
-        <div className="flex gap-3 flex-wrap items-end">
-          {/* Orientation */}
-          <div>
-            <label className="label py-0 mb-1">
-              <span className="label-text font-semibold text-sm">
-                {intl.formatMessage({ id: 'Jhvn5z', defaultMessage: 'Orientation', description: 'Widget orientation label' })}
-              </span>
-            </label>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                className={`btn btn-sm ${orientation === 'horizontal' ? 'btn-primary' : 'btn-outline'}`}
-                onClick={() => setOrientation('horizontal')}
-              >
-                {intl.formatMessage({ id: 'EXu3i+', defaultMessage: 'Horizontal', description: 'Horizontal orientation option' })}
-              </button>
-              <button
-                type="button"
-                className={`btn btn-sm ${orientation === 'vertical' ? 'btn-primary' : 'btn-outline'}`}
-                onClick={() => setOrientation('vertical')}
-              >
-                {intl.formatMessage({ id: 'TTN+1v', defaultMessage: 'Vertical', description: 'Vertical orientation option' })}
-              </button>
-            </div>
-          </div>
+    <div>
+      <StepIndicator current={step} onGoTo={setStep} />
 
-          {/* Theme */}
-          <div className="flex-1 min-w-[160px]">
-            <label className="label py-0 mb-1">
-              <span className="label-text font-semibold text-sm">
-                {intl.formatMessage({ id: '7Ha4j8', defaultMessage: 'Theme', description: 'Widget theme label' })}
-              </span>
-            </label>
-            <select
-              className="select select-bordered select-sm w-full"
-              value={selectedTheme}
-              onChange={(e) => setSelectedTheme(e.target.value)}
-              disabled={compatMode}
-            >
-              {AVAILABLE_THEMES.map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {/* Compat */}
-          <div>
-            <label className="label cursor-pointer justify-start gap-2 py-0">
-              <input type="checkbox" className="checkbox checkbox-sm checkbox-primary" checked={compatMode} onChange={(e) => setCompatMode(e.target.checked)} />
-              <span className="label-text text-sm">
-                {intl.formatMessage({ id: 'Qa4UgA', defaultMessage: 'Compatibility Mode', description: 'Compat mode checkbox label' })}
-              </span>
-            </label>
-            <div className="text-xs text-base-content/50 ml-6">
-              {intl.formatMessage({ id: '1JZBtk', defaultMessage: 'For OBS older than v31', description: 'Compat mode hint text' })}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Features */}
-      <div>
-        <label className="label py-0 mb-2">
-          <span className="label-text font-semibold">
-            {intl.formatMessage({ id: 'z5zM6j', defaultMessage: 'Features', description: 'Features section label' })}
-          </span>
-        </label>
-        <div className="space-y-2">
-          {features.map((f, i) => (
-            <FeatureCard
-              key={i}
-              feature={f}
-              index={i}
-              total={featureCount}
-              packs={packs}
-              onMoveUp={() => moveUp(i)}
-              onMoveDown={() => moveDown(i)}
-              onRemove={() => removeFeature(i)}
-              onChange={(updated) => updateFeature(i, updated)}
-            />
-          ))}
-        </div>
-
-        {/* Add Feature */}
-        {featureCount < 5 && (
-          <div className="relative mt-2" ref={addMenuRef}>
-            <button type="button" className="btn btn-sm btn-outline gap-1" onClick={() => setShowAddMenu((v) => !v)}>
-              <Plus className="w-3.5 h-3.5" />
-              {intl.formatMessage({ id: 'jPoSOu', defaultMessage: 'Add Feature', description: 'Add feature button label' })}
-            </button>
-            {showAddMenu && (
-              <div className="absolute top-full left-0 mt-1 bg-base-100 border border-base-300 rounded-lg shadow-xl z-10 min-w-[220px] py-1">
-                <button
-                  type="button"
-                  className={`w-full text-left px-4 py-2 text-sm hover:bg-base-200 transition ${hasProfile ? 'opacity-40 cursor-not-allowed' : ''}`}
-                  onClick={() => !hasProfile && addFeature({ type: 'profile' })}
-                >
-                  {intl.formatMessage({ id: 'ndGG1t', defaultMessage: 'Profile', description: 'Profile feature name in add menu' })}
-                  {hasProfile && (
-                    <span className="ml-2 text-xs text-base-content/50">
-                      {intl.formatMessage({ id: 'pT7MXb', defaultMessage: 'already added', description: 'Already added indicator in feature menu' })}
-                    </span>
-                  )}
-                </button>
-                <button
-                  type="button"
-                  className={`w-full text-left px-4 py-2 text-sm hover:bg-base-200 transition ${hasRecentPlays ? 'opacity-40 cursor-not-allowed' : ''}`}
-                  onClick={() => !hasRecentPlays && addFeature({ type: 'recentPlays', leaderboards: getDefaultLeaderboards(user) })}
-                >
-                  {intl.formatMessage({ id: '/PBHyq', defaultMessage: 'Recent Plays', description: 'Recent plays feature name in add menu' })}
-                  {hasRecentPlays && (
-                    <span className="ml-2 text-xs text-base-content/50">
-                      {intl.formatMessage({ id: 'pT7MXb', defaultMessage: 'already added', description: 'Already added indicator in feature menu' })}
-                    </span>
-                  )}
-                </button>
-                <button
-                  type="button"
-                  className={`w-full text-left px-4 py-2 text-sm hover:bg-base-200 transition ${!defaultPack ? 'opacity-40 cursor-not-allowed' : ''}`}
-                  onClick={() =>
-                    defaultPack &&
-                    addFeature({
-                      type: 'packLeaderboard',
-                      packId: defaultPack.id,
-                      packName: defaultPack.name,
-                      bannerUrl: bestBannerUrl(defaultPack),
-                      difficulty: 'challenge',
-                      leaderboards: getDefaultLeaderboards(user),
-                    })
-                  }
-                >
-                  {intl.formatMessage({ id: 'B6ktnP', defaultMessage: 'Pack Leaderboard', description: 'Pack leaderboard feature name in add menu' })}
-                  {!defaultPack && (
-                    <span className="ml-2 text-xs text-base-content/50">
-                      {intl.formatMessage({ id: 'VlCXVh', defaultMessage: 'no packs available', description: 'No packs available indicator' })}
-                    </span>
-                  )}
-                </button>
-              </div>
-            )}
-          </div>
-        )}
-        {featureCount >= 5 && (
-          <p className="text-xs text-base-content/50 mt-2">
-            {intl.formatMessage({ id: 'TL6lMm', defaultMessage: 'Maximum of 5 features reached.', description: 'Max features reached message' })}
-          </p>
-        )}
-      </div>
-
-      {/* Preview */}
-      <div>
-        <label className="label py-0 mb-2">
-          <span className="label-text font-semibold">
-            {intl.formatMessage({ id: 'Lh3mLz', defaultMessage: 'Preview', description: 'Preview section label' })}
-          </span>
-        </label>
-        <div className="bg-base-200 rounded-lg p-4 flex items-center justify-center overflow-auto">
-          <iframe src={widgetUrl} width={widgetWidth} height={widgetHeight} className="border-0 rounded shadow-xl" style={{ backgroundColor: 'transparent' }} />
-        </div>
-      </div>
-
-      {/* OBS Setup */}
-      <div className="alert alert-info">
-        <div className="flex flex-col gap-2 text-sm w-full">
-          <div className="font-semibold">{intl.formatMessage({ id: '0a8qQn', defaultMessage: 'OBS Setup', description: 'OBS setup section heading' })}</div>
-          {!compatMode && (
-            <div className="text-warning font-medium">
-              {intl.formatMessage({ id: 'pilwMh', defaultMessage: 'OBS Studio v31 or higher required for themes.', description: 'OBS version warning' })}
-            </div>
-          )}
-          <div className="flex flex-col gap-1 text-base-content/80">
-            <div>{intl.formatMessage({ id: 'xHjitK', defaultMessage: '1. Add a Browser Source in OBS', description: 'OBS setup step 1' })}</div>
-            <div>{intl.formatMessage({ id: 'FBSgTm', defaultMessage: '2. Paste the URL below', description: 'OBS setup step 2' })}</div>
-            <div>
-              {intl.formatMessage(
-                { id: 'a9j6HF', defaultMessage: '3. Set Width: {width}px, Height: {height}px', description: 'OBS setup step 3 with dimensions' },
-                { width: widgetWidth, height: widgetHeight },
-              )}
-            </div>
-            <div>
-              {intl.formatMessage({
-                id: 'D06P28',
-                defaultMessage: '4. Enable "Shutdown source when not visible" and "Refresh browser when scene becomes active"',
-                description: 'OBS setup step 4',
-              })}
-            </div>
-          </div>
-          <div className="flex gap-2 mt-1">
-            <input type="text" value={widgetUrl} readOnly className="input input-sm input-bordered flex-1 font-mono text-xs" />
-            <button className="btn btn-sm btn-primary" onClick={copyToClipboard}>
-              {copied
-                ? intl.formatMessage({ id: 'EDgCxn', defaultMessage: 'Copied!', description: 'URL copied confirmation' })
-                : intl.formatMessage({ id: 'DsKB1w', defaultMessage: 'Copy URL', description: 'Copy URL button label' })}
-            </button>
-          </div>
-        </div>
-      </div>
+      {step === 1 && <LayoutStep orientation={orientation} setOrientation={setOrientation} onNext={() => setStep(2)} />}
+      {step === 2 && (
+        <FeaturesStep
+          features={features}
+          setFeatures={setFeatures}
+          packs={packs}
+          user={user}
+          previewUrl={widgetUrl}
+          widgetWidth={widgetWidth}
+          widgetHeight={widgetHeight}
+          onBack={() => setStep(1)}
+          onNext={() => setStep(3)}
+        />
+      )}
+      {step === 3 && (
+        <AppearanceStep
+          selectedTheme={selectedTheme}
+          setSelectedTheme={setSelectedTheme}
+          compatMode={compatMode}
+          previewUrl={widgetUrl}
+          widgetWidth={widgetWidth}
+          widgetHeight={widgetHeight}
+          onBack={() => setStep(2)}
+          onNext={() => setStep(4)}
+        />
+      )}
+      {step === 4 && (
+        <SetupStreamStep
+          widgetUrl={widgetUrl}
+          widgetWidth={widgetWidth}
+          widgetHeight={widgetHeight}
+          compatMode={compatMode}
+          setCompatMode={setCompatMode}
+          previewUrl={widgetUrl}
+          onBack={() => setStep(3)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/widget/StreamerWidgetPage.tsx
+++ b/frontend/src/pages/widget/StreamerWidgetPage.tsx
@@ -3,12 +3,25 @@ import { useSearchParams } from 'react-router-dom';
 import { getWidgetData } from '../../services/api';
 import type { WidgetDataResponse } from '../../schemas/apiSchemas';
 import { useWebSocket } from '../../hooks/useWebSocket';
-import { decodeWidgetConfig, getWidgetDimensions, type WidgetConfig } from '../../utils/widgetConfig';
+import {
+  decodeWidgetConfig,
+  getWidgetDimensions,
+  type WidgetConfig,
+  type LeaderboardKey,
+  PANEL_WIDTH,
+  PANEL_HEIGHT,
+  PROFILE_HEADER_H,
+} from '../../utils/widgetConfig';
 import { ProfileStatsPanel } from './panels/ProfileStatsPanel';
 import { RecentPlaysPanel } from './panels/RecentPlaysPanel';
 import { PackLeaderboardPanel } from './panels/PackLeaderboardPanel';
+import { SessionPanel } from './panels/SessionPanel';
 
-const WIDGET_KEYFRAMES = `@keyframes widgetFadeIn { from { opacity: 0 } to { opacity: 1 } }`;
+const WIDGET_KEYFRAMES = `
+  html, body, #root { background: transparent !important; background-color: transparent !important; }
+  @keyframes widgetFadeIn { from { opacity: 0 } to { opacity: 1 } }
+  @keyframes aliasMarquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+`;
 
 export const StreamerWidgetPage: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -21,7 +34,7 @@ export const StreamerWidgetPage: React.FC = () => {
   const compatMode = searchParams.get('compat') === 'true';
 
   const config: WidgetConfig | null = configParam ? decodeWidgetConfig(configParam) : null;
-  const { width: totalWidth, height: totalHeight } = config ? getWidgetDimensions(config) : { width: 235, height: 300 };
+  const { width: totalWidth, height: totalHeight } = config ? getWidgetDimensions(config) : { width: PANEL_WIDTH, height: PANEL_HEIGHT + PROFILE_HEADER_H };
 
   const WS_URL = (import.meta as any).env?.VITE_WEBSOCKET_URL || '';
   const { isConnected: wsConnected, lastMessage } = useWebSocket({
@@ -51,7 +64,12 @@ export const StreamerWidgetPage: React.FC = () => {
 
   useEffect(() => {
     if (!lastMessage || !userIdParam) return;
-    if (lastMessage.type === 'refresh' || lastMessage.type === 'widgetUpdate') {
+    const isRelevantEvent =
+      lastMessage.type === 'playSubmitted' || // play written — refresh recent plays
+      lastMessage.type === 'sessionUpdate' || // session written — refresh session panel
+      lastMessage.type === 'refresh' || // generic refresh (e.g. pack leaderboard)
+      lastMessage.type === 'widgetUpdate';
+    if (isRelevantEvent) {
       const messageUserId = (lastMessage as any).userId ?? (lastMessage as any).data?.userId;
       if (!messageUserId || messageUserId === userIdParam) {
         getWidgetData(userIdParam, configParam || undefined)
@@ -117,17 +135,37 @@ export const StreamerWidgetPage: React.FC = () => {
     } else {
       document.documentElement.setAttribute('data-theme', themeParam || 'arrow-blue');
     }
-    document.body.style.backgroundColor = 'transparent';
-    document.documentElement.style.backgroundColor = 'transparent';
+    // Strip the bg-base-200 class that index.html puts on #root, then force all
+    // ancestor elements to transparent so the OBS scene shows through on any theme.
+    const makeTransparent = (el: HTMLElement) => {
+      el.style.setProperty('background', 'transparent', 'important');
+      el.style.setProperty('background-color', 'transparent', 'important');
+    };
+    const clearTransparent = (el: HTMLElement) => {
+      el.style.removeProperty('background');
+      el.style.removeProperty('background-color');
+    };
+    makeTransparent(document.body);
+    makeTransparent(document.documentElement);
+    const rootEl = document.getElementById('root');
+    if (rootEl) {
+      rootEl.classList.remove('bg-base-200');
+      makeTransparent(rootEl);
+    }
     return () => {
-      document.body.style.backgroundColor = '';
-      document.documentElement.style.backgroundColor = '';
+      clearTransparent(document.body);
+      clearTransparent(document.documentElement);
+      if (rootEl) {
+        rootEl.classList.add('bg-base-200');
+        clearTransparent(rootEl);
+      }
     };
   }, [themeParam, compatMode]);
 
   if (loading) {
     return (
       <div className="w-full h-screen bg-transparent flex items-center justify-center">
+        <style>{WIDGET_KEYFRAMES}</style>
         <div style={{ width: totalWidth, height: totalHeight }} className="bg-base-200 flex items-center justify-center">
           <div className="loading loading-spinner loading-lg text-primary" />
         </div>
@@ -137,8 +175,16 @@ export const StreamerWidgetPage: React.FC = () => {
 
   if (!widgetData) return null;
 
-  const features = config?.features ?? [{ type: 'profile' as const }];
-  const isHorizontal = config?.orientation === 'horizontal';
+  const orientation = config?.orientation ?? 'horizontal';
+  const isHorizontal = orientation === 'horizontal';
+
+  // Strip legacy 'profile' entries from old encoded configs — profile is now always-on at the top
+  const rawFeatures = config?.features ?? [];
+  const filteredFeatures = rawFeatures.filter((f) => (f as any).type !== 'profile');
+  const activeFeatures =
+    filteredFeatures.length > 0
+      ? filteredFeatures
+      : [{ type: 'currentSession' as const }, { type: 'recentPlays' as const, leaderboards: ['EX' as LeaderboardKey] }];
 
   return (
     <div className="w-full h-screen flex items-center justify-center p-0 bg-transparent">
@@ -152,31 +198,37 @@ export const StreamerWidgetPage: React.FC = () => {
         </div>
       )}
 
-      <div style={{ width: totalWidth, height: totalHeight }} className={`flex ${isHorizontal ? 'flex-row' : 'flex-col'} overflow-hidden`}>
-        {features.map((feature, i) => {
-          const orientation = config?.orientation ?? 'vertical';
-          if (feature.type === 'profile') {
-            return <ProfileStatsPanel key={i} user={widgetData.user} orientation={orientation} />;
-          }
-          if (feature.type === 'recentPlays') {
-            return <RecentPlaysPanel key={i} plays={widgetData.recentPlays ?? []} leaderboards={feature.leaderboards} orientation={orientation} />;
-          }
-          if (feature.type === 'packLeaderboard') {
-            const packData = widgetData.packLeaderboards?.[feature.packId];
-            if (!packData) return null;
-            return (
-              <PackLeaderboardPanel
-                key={i}
-                packName={feature.packName}
-                bannerUrl={feature.bannerUrl}
-                data={packData}
-                leaderboards={feature.leaderboards}
-                orientation={orientation}
-              />
-            );
-          }
-          return null;
-        })}
+      <div style={{ width: totalWidth, height: totalHeight, backgroundColor: 'transparent' }} className="flex flex-col overflow-hidden">
+        {/* Profile is always rendered at the top, full width, transparent */}
+        <ProfileStatsPanel user={widgetData.user} />
+
+        {/* Feature panels below — side by side (horizontal) or stacked (vertical) */}
+        <div className={`flex ${isHorizontal ? 'flex-row' : 'flex-col'} flex-1 overflow-hidden`}>
+          {activeFeatures.map((feature, i) => {
+            if (feature.type === 'recentPlays') {
+              return <RecentPlaysPanel key={i} plays={widgetData.recentPlays ?? []} leaderboards={feature.leaderboards} orientation={orientation} />;
+            }
+            if (feature.type === 'packLeaderboard') {
+              const packData = widgetData.packLeaderboards?.[feature.packId];
+              if (!packData) return null;
+              return (
+                <PackLeaderboardPanel
+                  key={i}
+                  packName={feature.packName}
+                  bannerUrl={feature.bannerUrl}
+                  difficulty={feature.difficulty}
+                  data={packData}
+                  leaderboards={feature.leaderboards}
+                  orientation={orientation}
+                />
+              );
+            }
+            if (feature.type === 'currentSession') {
+              return <SessionPanel key={i} session={widgetData.currentSession} orientation={orientation} />;
+            }
+            return null;
+          })}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/widget/panels/PackLeaderboardPanel.tsx
+++ b/frontend/src/pages/widget/panels/PackLeaderboardPanel.tsx
@@ -1,27 +1,44 @@
 /* eslint-disable formatjs/no-literal-string-in-jsx */
 import React from 'react';
+import { Swords } from 'lucide-react';
 import { BannerImage } from '../../../components/ui/BannerImage';
 import type { WidgetPackLeaderboard } from '../../../schemas/apiSchemas';
-import { PANEL_WIDTH, PANEL_HEIGHT, COMPACT_HEIGHTS, type LeaderboardKey } from '../../../utils/widgetConfig';
+import {
+  PANEL_WIDTH,
+  PANEL_HEIGHT,
+  COMPACT_HEIGHTS,
+  HORIZONTAL_WIDTHS,
+  type LeaderboardKey,
+  type PackLeaderboardDifficulty,
+} from '../../../utils/widgetConfig';
 import { useRotatingIndex } from './useRotatingIndex';
 
 const LB_LABELS: Record<LeaderboardKey, string> = { HardEX: 'H.EX', EX: 'EX', ITG: 'ITG' };
 const LB_COLORS: Record<LeaderboardKey, string> = { HardEX: '#FF69B4', EX: '#21CCE8', ITG: '#ffffff' };
+const DIFFICULTY_LABELS: Record<PackLeaderboardDifficulty, string> = { medium: 'Med', hard: 'Hard', challenge: 'Expert' };
 const FADE_IN: React.CSSProperties = { animation: 'widgetFadeIn 0.4s ease' };
+
+function fmtScore(n: number): string {
+  if (n >= 100000) return `${Math.round(n / 1000)}k`;
+  if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
+  return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
 
 interface Props {
   packName: string;
   bannerUrl: string | null;
+  difficulty?: PackLeaderboardDifficulty;
   data: WidgetPackLeaderboard;
   leaderboards: LeaderboardKey[];
   orientation: 'horizontal' | 'vertical';
 }
 
-export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, data, leaderboards, orientation }) => {
+export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, difficulty, data, leaderboards, orientation }) => {
   const idx = useRotatingIndex(leaderboards.length);
   const activeLb = leaderboards[idx];
   const entry = data.leaderboards[activeLb];
   const lbColor = LB_COLORS[activeLb];
+  const nearby = entry?.nearby;
 
   if (orientation === 'vertical') {
     return (
@@ -32,7 +49,6 @@ export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, dat
         <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-accent/5 pointer-events-none" />
         <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-transparent via-primary/50 to-transparent" />
 
-        {/* Small banner — static */}
         {bannerUrl && (
           <div className="flex-shrink-0 rounded overflow-hidden" style={{ width: 51, height: 20 }}>
             <BannerImage bannerUrl={bannerUrl} alt={packName} className="w-full h-full object-cover" />
@@ -40,15 +56,17 @@ export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, dat
         )}
 
         <div className="flex-1 min-w-0 z-10">
-          {/* Pack name + badge row */}
           <div className="flex items-center gap-1 mb-0.5">
             <span className="text-[11px] font-bold text-base-content/70 truncate">{packName}</span>
-            {/* Badge — fades with leaderboard color */}
+            {difficulty && (
+              <span className="text-[8px] font-bold px-1 py-0.5 rounded text-base-content/40 bg-base-content/10 flex-shrink-0">
+                {DIFFICULTY_LABELS[difficulty]}
+              </span>
+            )}
             <span key={activeLb} className="text-[9px] font-bold px-1 py-0.5 rounded bg-black/50 flex-shrink-0" style={{ color: lbColor, ...FADE_IN }}>
               {LB_LABELS[activeLb]}
             </span>
           </div>
-          {/* Rank + score — fades */}
           {entry ? (
             <div key={activeLb} className="flex items-baseline gap-2" style={FADE_IN}>
               <span className="text-xl font-black leading-none" style={{ color: lbColor }}>
@@ -56,7 +74,7 @@ export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, dat
               </span>
               <span className="text-[10px] text-base-content/40">of {entry.totalParticipants}</span>
               <span className="text-sm font-bold ml-auto" style={{ color: lbColor }}>
-                {entry.totalScore.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                {fmtScore(entry.totalScore)}
                 <span className="text-[10px] font-normal text-base-content/40 ml-0.5">pts</span>
               </span>
             </div>
@@ -70,19 +88,15 @@ export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, dat
     );
   }
 
-  // Horizontal: banner at top, rank + score below
-  const BANNER_H = 100;
+  // Horizontal: banner on top with overlaid badges, rank+score bottom-left, nearby list bottom-right
+  const W = HORIZONTAL_WIDTHS['packLeaderboard'];
+  const BANNER_H = 90;
   const bodyH = PANEL_HEIGHT - BANNER_H;
+  const LEFT_W = 88;
 
   return (
-    <div
-      style={{ width: PANEL_WIDTH, height: PANEL_HEIGHT }}
-      className="relative flex flex-col overflow-hidden bg-gradient-to-br from-base-200 via-base-300 to-base-200"
-    >
-      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-accent/50 to-transparent z-10" />
-      <div className="absolute inset-0 bg-gradient-to-tr from-primary/5 via-transparent to-accent/5 pointer-events-none" />
-
-      {/* Banner — static */}
+    <div style={{ width: W, height: PANEL_HEIGHT }} className="relative flex flex-col overflow-hidden bg-base-200">
+      {/* Banner */}
       <div style={{ height: BANNER_H }} className="flex-shrink-0 relative overflow-hidden">
         {bannerUrl ? (
           <BannerImage bannerUrl={bannerUrl} alt={packName} className="w-full h-full object-cover" />
@@ -92,33 +106,63 @@ export const PackLeaderboardPanel: React.FC<Props> = ({ packName, bannerUrl, dat
           </div>
         )}
         <div className="absolute inset-0 bg-gradient-to-b from-transparent to-base-200/80" />
-        {/* Badge — fades with leaderboard color */}
-        <div className="absolute bottom-1 right-2">
-          <span key={activeLb} className="text-[11px] font-bold px-1.5 py-0.5 rounded bg-black/60" style={{ color: lbColor, ...FADE_IN }}>
+        {/* Badges bottom-right */}
+        <div className="absolute bottom-1.5 right-2 flex items-center gap-1">
+          {difficulty && <span className="text-[8px] font-bold px-1 py-0.5 rounded bg-black/60 text-white/60">{DIFFICULTY_LABELS[difficulty]}</span>}
+          <span key={activeLb} className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-black/60" style={{ color: lbColor, ...FADE_IN }}>
             {LB_LABELS[activeLb]}
           </span>
         </div>
       </div>
 
-      {/* Rank + score — fades with leaderboard color */}
-      <div style={{ height: bodyH }} className="flex flex-col items-center justify-center z-10 gap-1">
-        <span className="text-xs font-semibold text-base-content/50 truncate px-2 max-w-full">{packName}</span>
-        {entry ? (
-          <div key={activeLb} className="flex flex-col items-center gap-1" style={FADE_IN}>
-            <div className="text-4xl font-black drop-shadow-lg leading-none" style={{ color: lbColor }}>
-              #{entry.rank}
-            </div>
-            <div className="text-xs text-base-content/40">of {entry.totalParticipants}</div>
-            <div className="mt-2 bg-black/30 rounded-lg px-3 py-1 backdrop-blur-sm">
-              <span className="text-xl font-bold" style={{ color: lbColor }}>
-                {entry.totalScore.toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                <span className="text-xs font-normal text-base-content/40 ml-1">pts</span>
+      {/* Body: rank+score left | divider | nearby list right */}
+      <div style={{ height: bodyH }} className="flex flex-row flex-shrink-0">
+        {/* Left: user rank + score */}
+        <div style={{ width: LEFT_W }} className="flex flex-col items-center justify-center px-2 flex-shrink-0">
+          {entry ? (
+            <div key={activeLb} className="flex flex-col items-center gap-0.5" style={FADE_IN}>
+              <span className="text-3xl font-black leading-none" style={{ color: lbColor }}>
+                #{entry.rank}
               </span>
+              <span className="text-[9px] text-base-content/40">of {entry.totalParticipants}</span>
+              <div className="mt-1.5 bg-base-300/60 rounded-md px-1.5 py-0.5">
+                <span className="text-xs font-bold" style={{ color: lbColor }}>
+                  {fmtScore(entry.totalScore)}
+                </span>
+                <span className="text-[9px] text-base-content/40 ml-0.5">pts</span>
+              </div>
             </div>
-          </div>
-        ) : (
-          <div key={activeLb} className="text-sm text-base-content/40" style={FADE_IN}>
-            No scores yet
+          ) : (
+            <div key={activeLb} className="text-xs text-base-content/40 text-center" style={FADE_IN}>
+              No scores
+            </div>
+          )}
+        </div>
+
+        {/* Vertical divider */}
+        <div className="w-px bg-base-content/10 flex-shrink-0 my-2" />
+
+        {/* Right: nearby players */}
+        {nearby && nearby.length > 0 && (
+          <div key={activeLb} className="flex-1 flex flex-col justify-around px-2 py-1.5 min-w-0" style={FADE_IN}>
+            {nearby.map((p) => (
+              <div key={p.userId} className="flex items-center gap-1 min-w-0" style={{ opacity: p.isSelf || p.isRival ? 1 : 0.5 }}>
+                <span
+                  className="text-[9px] font-bold w-4 text-right flex-shrink-0 tabular-nums"
+                  style={{ color: p.isSelf ? lbColor : p.isRival ? 'hsl(var(--er))' : 'hsl(var(--bc))' }}
+                >
+                  {p.rank}
+                </span>
+                <span
+                  className={`text-[10px] flex-1 min-w-0 truncate ${p.isSelf || p.isRival ? 'font-bold' : 'font-medium'}`}
+                  style={{ color: p.isSelf ? lbColor : p.isRival ? 'hsl(var(--er))' : 'hsl(var(--bc))' }}
+                >
+                  {p.alias}
+                </span>
+                {p.isRival && <Swords className="w-2.5 h-2.5 flex-shrink-0 text-error" />}
+                <span className="text-[9px] text-base-content/50 flex-shrink-0 tabular-nums">{fmtScore(p.totalScore)}</span>
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/frontend/src/pages/widget/panels/ProfileStatsPanel.tsx
+++ b/frontend/src/pages/widget/panels/ProfileStatsPanel.tsx
@@ -1,43 +1,45 @@
 import React from 'react';
 import { ProfileAvatar } from '../../../components';
 import type { WidgetDataResponse } from '../../../schemas/apiSchemas';
-import { PANEL_WIDTH, PANEL_HEIGHT, COMPACT_HEIGHTS, HORIZONTAL_WIDTHS } from '../../../utils/widgetConfig';
+import { PROFILE_HEADER_H } from '../../../utils/widgetConfig';
 
 interface Props {
   user: WidgetDataResponse['user'];
-  orientation: 'horizontal' | 'vertical';
 }
 
-export const ProfileStatsPanel: React.FC<Props> = ({ user, orientation }) => {
-  if (orientation === 'vertical') {
-    return (
-      <div
-        style={{ width: PANEL_WIDTH, height: COMPACT_HEIGHTS.profile }}
-        className="relative flex items-center gap-3 px-3 overflow-hidden bg-gradient-to-r from-base-200 via-base-300 to-base-200 border-b border-base-300/30"
-      >
-        <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-transparent via-primary/50 to-transparent" />
-        <div className="relative flex-shrink-0">
-          <div className="absolute inset-0 bg-primary/20 rounded-full blur-md" />
-          <ProfileAvatar alias={user.alias} profileImageUrl={user.profileImageUrl ?? null} size="sm" />
-        </div>
-        <span className="text-sm font-bold text-primary truncate z-10">{user.alias}</span>
-      </div>
-    );
-  }
+const SHADOW = '0 1px 4px rgba(0,0,0,0.9), 0 0 12px rgba(0,0,0,0.5)';
+const MARQUEE_THRESHOLD = 16;
+
+export const ProfileStatsPanel: React.FC<Props> = ({ user }) => {
+  const isMarquee = user.alias.length > MARQUEE_THRESHOLD;
 
   return (
-    <div
-      style={{ width: HORIZONTAL_WIDTHS.profile, height: PANEL_HEIGHT }}
-      className="relative flex flex-col items-center justify-center gap-4 overflow-hidden bg-gradient-to-br from-base-200 via-base-300 to-base-200"
-    >
-      <div className="absolute top-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
-      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-accent/50 to-transparent" />
-      <div className="absolute inset-0 bg-gradient-to-tr from-primary/5 via-transparent to-accent/5 pointer-events-none" />
-      <div className="relative z-10">
-        <div className="absolute inset-0 bg-primary/20 rounded-full blur-xl" />
-        <ProfileAvatar alias={user.alias} profileImageUrl={user.profileImageUrl ?? null} size="lg" />
+    <div style={{ height: PROFILE_HEADER_H, background: 'transparent' }} className="w-full flex items-center pl-2 pr-4 gap-2 flex-shrink-0">
+      {/* Avatar — ring gives definition on any OBS background */}
+      <div className="flex-shrink-0 ring-2 ring-white/20 rounded-full">
+        <ProfileAvatar alias={user.alias} profileImageUrl={user.profileImageUrl ?? null} size="sm" />
       </div>
-      <div className="text-xl font-bold text-primary drop-shadow-lg text-center truncate w-full px-4 z-10">{user.alias}</div>
+
+      {/* Alias — marquee for long names */}
+      <div className="flex-1 min-w-0 overflow-hidden">
+        {isMarquee ? (
+          <div className="overflow-hidden" style={{ WebkitMaskImage: 'linear-gradient(to right, black 80%, transparent 100%)' }}>
+            <span
+              className="inline-block whitespace-nowrap text-sm font-bold text-white"
+              style={{ animation: 'aliasMarquee 14s linear infinite', textShadow: SHADOW }}
+            >
+              {user.alias}
+              <span className="inline-block w-12" aria-hidden="true" />
+              {user.alias}
+              <span className="inline-block w-12" aria-hidden="true" />
+            </span>
+          </div>
+        ) : (
+          <span className="block truncate text-sm font-bold text-white" style={{ textShadow: SHADOW }}>
+            {user.alias}
+          </span>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/widget/panels/RecentPlaysPanel.tsx
+++ b/frontend/src/pages/widget/panels/RecentPlaysPanel.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { BannerImage } from '../../../components/ui/BannerImage';
 import { GradeImage } from '../../../components/GradeImage';
+import { DifficultyChip } from '../../../components/DifficultyChip';
 import type { WidgetRecentPlay } from '../../../schemas/apiSchemas';
 import { PANEL_WIDTH, PANEL_HEIGHT, COMPACT_HEIGHTS, HORIZONTAL_WIDTHS, type LeaderboardKey } from '../../../utils/widgetConfig';
 import { useRotatingIndex } from './useRotatingIndex';
@@ -14,6 +15,16 @@ const MAX_PLAYS = 3;
 const HEADER_H = 28;
 const SCORE_FONT: React.CSSProperties = { fontFamily: "'Nunito', sans-serif", fontWeight: 800 };
 const FADE_IN: React.CSSProperties = { animation: 'widgetFadeIn 0.4s ease' };
+
+// Strip 1-2 leading [number] groups from the title, return them as tags
+function parseTitleBrackets(raw: string): { tags: string; title: string } {
+  const match = raw.match(/^((?:\[\d+\]\s*){1,2})([\s\S]*)/);
+  if (match && match[1]) {
+    const title = match[2].trim();
+    return { tags: match[1].trim(), title: title || raw };
+  }
+  return { tags: '', title: raw };
+}
 
 interface Props {
   plays: WidgetRecentPlay[];
@@ -28,33 +39,46 @@ export const RecentPlaysPanel: React.FC<Props> = ({ plays, leaderboards, orienta
 
   const rows = plays.slice(0, MAX_PLAYS).map((play, i) => {
     const matchingLb = play.leaderboards.find((l) => (LB_KEY_FOR_TYPE[l.leaderboard] ?? l.leaderboard) === activeLb);
+    const { tags, title } = parseTitleBrackets(play.chart.title ?? 'Unknown');
     return {
       i,
-      title: play.chart.title ?? 'Unknown',
+      tags,
+      title,
+      artist: play.chart.artist ?? null,
       score: matchingLb?.data?.score,
       grade: matchingLb?.data?.grade,
       chart: play.chart,
     };
   });
 
+  // Shared header — glowing left accent strip changes color with active leaderboard
+  const header = (
+    <div
+      style={{ height: HEADER_H }}
+      className="relative flex items-center justify-between px-3 flex-shrink-0 bg-base-300/80 z-10 border-b border-base-content/10"
+    >
+      {/* Left accent — leaderboard color glow */}
+      <div
+        className="absolute left-0 inset-y-0 w-[3px]"
+        style={{ backgroundColor: lbColor, boxShadow: `0 0 8px 2px ${lbColor}`, transition: 'background-color 0.3s ease, box-shadow 0.3s ease' }}
+      />
+      <span className="text-[11px] font-semibold text-base-content/75 tracking-wide pl-1">Recent Plays</span>
+      <span key={activeLb} className="text-[10px] font-bold px-2 py-0.5 rounded-full mr-5" style={{ color: lbColor, background: `${lbColor}22`, ...FADE_IN }}>
+        {LB_LABELS[activeLb]}
+      </span>
+    </div>
+  );
+
   if (orientation === 'vertical') {
-    const ROW_H = Math.floor((COMPACT_HEIGHTS.recentPlays - HEADER_H) / MAX_PLAYS);
     return (
       <div style={{ width: PANEL_WIDTH, height: COMPACT_HEIGHTS.recentPlays }} className="relative flex flex-col overflow-hidden border-b border-base-300/30">
         <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-transparent via-accent/50 to-transparent z-10" />
-
-        <div style={{ height: HEADER_H }} className="flex items-center justify-between px-3 flex-shrink-0 border-b border-base-300/20 bg-base-300/60 z-10">
-          <span className="text-[10px] font-bold text-base-content/70 uppercase tracking-wider">Recent Plays</span>
-          <span key={activeLb} className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-black/50 mr-5" style={{ color: lbColor, ...FADE_IN }}>
-            {LB_LABELS[activeLb]}
-          </span>
-        </div>
-
+        {header}
         {rows.length === 0 ? (
-          <div className="flex items-center justify-center flex-1 text-xs text-base-content/30 bg-base-200">No recent plays</div>
+          <div className="flex items-center justify-center flex-1 text-xs text-white/30 bg-black/40">No recent plays</div>
         ) : (
-          rows.map(({ i, title, score, grade, chart }) => (
-            <div key={i} style={{ height: ROW_H }} className="relative flex-shrink-0 overflow-hidden">
+          rows.map(({ i, tags, title, score, grade, chart }) => (
+            <div key={i} className="relative flex-1 overflow-hidden">
               <div className="absolute inset-0">
                 <BannerImage
                   bannerUrl={chart.bannerUrl}
@@ -64,20 +88,27 @@ export const RecentPlaysPanel: React.FC<Props> = ({ plays, leaderboards, orienta
                   alt={title}
                   className="w-full h-full object-cover scale-110"
                 />
-                <div className="absolute inset-0 bg-gradient-to-r from-base-300/70 via-base-300/60 to-base-300/80" />
+                <div className="absolute inset-0 bg-gradient-to-r from-black/80 via-black/50 to-black/70" />
               </div>
               <div className="relative z-10 flex items-center gap-2 h-full px-2">
                 <div className="flex-1 min-w-0">
-                  <div className="text-xs font-bold text-white leading-tight truncate drop-shadow">{title}</div>
-                </div>
-                {/* Grade + score in one pill */}
-                <div className="flex items-center gap-1 bg-black/50 rounded px-1 py-0.5 flex-shrink-0">
-                  {grade && <GradeImage grade={grade} className="w-4 h-4" />}
-                  {score && (
-                    <span key={`${i}-${activeLb}`} className="text-xs leading-tight drop-shadow" style={{ ...SCORE_FONT, color: lbColor, ...FADE_IN }}>
-                      {score}
-                    </span>
+                  {tags && (
+                    <div className="text-[8px] font-semibold leading-none truncate mb-px" style={{ color: lbColor, opacity: 0.7 }}>
+                      {tags}
+                    </div>
                   )}
+                  <div className="text-[11px] font-bold text-white leading-tight truncate">{title}</div>
+                </div>
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  <DifficultyChip stepsType={chart.stepsType} difficulty={chart.difficulty} meter={chart.meter} size="sm" />
+                  <div className="flex items-center gap-1 bg-black/50 rounded px-1 py-0.5">
+                    {grade && <GradeImage grade={grade} className="w-4 h-4" />}
+                    {score && (
+                      <span key={`${i}-${activeLb}`} className="text-xs leading-none" style={{ ...SCORE_FONT, color: lbColor, ...FADE_IN }}>
+                        {score}
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
@@ -89,25 +120,18 @@ export const RecentPlaysPanel: React.FC<Props> = ({ plays, leaderboards, orienta
 
   // Horizontal
   const W = HORIZONTAL_WIDTHS['recentPlays'];
-  const ROW_H = Math.floor((PANEL_HEIGHT - HEADER_H) / MAX_PLAYS);
 
   return (
     <div style={{ width: W, height: PANEL_HEIGHT }} className="relative flex flex-col overflow-hidden">
-      <div className="absolute top-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-primary/60 to-transparent z-10" />
-      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-transparent via-accent/60 to-transparent z-10" />
-
-      <div style={{ height: HEADER_H }} className="flex items-center justify-between px-3 flex-shrink-0 bg-base-300/80 z-10 border-b border-base-300/40">
-        <span className="text-xs font-bold text-base-content/80 uppercase tracking-wide">Recent Plays</span>
-        <span key={activeLb} className="text-[11px] font-bold px-1.5 py-0.5 rounded bg-black/50 mr-5" style={{ color: lbColor, ...FADE_IN }}>
-          {LB_LABELS[activeLb]}
-        </span>
-      </div>
-
+      <div className="absolute top-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-white/10 to-transparent z-10" />
+      <div className="absolute bottom-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-white/10 to-transparent z-10" />
+      {header}
       {rows.length === 0 ? (
-        <div className="flex items-center justify-center flex-1 text-sm text-base-content/40 bg-base-200">No recent plays</div>
+        <div className="flex items-center justify-center flex-1 text-sm text-white/30 bg-black/40">No recent plays</div>
       ) : (
-        rows.map(({ i, title, score, grade, chart }) => (
-          <div key={i} style={{ height: ROW_H }} className="relative flex-shrink-0 overflow-hidden">
+        rows.map(({ i, tags, title, artist, score, grade, chart }) => (
+          <div key={i} className="relative flex-1 overflow-hidden">
+            {/* Background: banner + gradient */}
             <div className="absolute inset-0">
               <BannerImage
                 bannerUrl={chart.bannerUrl}
@@ -117,24 +141,33 @@ export const RecentPlaysPanel: React.FC<Props> = ({ plays, leaderboards, orienta
                 alt={title}
                 className="w-full h-full object-cover scale-110"
               />
-              <div className="absolute inset-0 bg-gradient-to-r from-black/75 via-black/40 to-black/65" />
+              <div className="absolute inset-0 bg-gradient-to-r from-black/85 via-black/55 to-black/75" />
               <div className="absolute bottom-0 left-0 w-full h-px bg-white/5" />
             </div>
 
             <div className="relative z-10 flex items-center h-full px-3 gap-3">
-              {/* Title — takes all available space */}
-              <div className="flex-1 min-w-0">
-                <div className="text-base font-bold text-white leading-tight truncate drop-shadow-md">{title}</div>
+              {/* Metadata: tags → title → artist */}
+              <div className="flex-1 min-w-0 flex flex-col justify-center">
+                {tags && (
+                  <div className="text-[9px] font-bold leading-none truncate mb-0.5" style={{ color: lbColor, opacity: 0.65 }}>
+                    {tags}
+                  </div>
+                )}
+                <div className="text-[13px] font-bold text-white leading-snug truncate">{title}</div>
+                {artist && <div className="text-[10px] text-white/45 leading-snug truncate mt-px">{artist}</div>}
               </div>
 
-              {/* Grade + score in one pill; grade is static, score fades */}
-              <div className="flex items-center gap-1.5 bg-black/55 backdrop-blur-sm rounded-lg px-2 py-1 flex-shrink-0">
-                {grade && <GradeImage grade={grade} className="w-7 h-7 drop-shadow" />}
-                {score && (
-                  <span key={`${i}-${activeLb}`} className="text-base leading-none drop-shadow-md" style={{ ...SCORE_FONT, color: lbColor, ...FADE_IN }}>
-                    {score}
-                  </span>
-                )}
+              {/* Difficulty + score + grade */}
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <DifficultyChip stepsType={chart.stepsType} difficulty={chart.difficulty} meter={chart.meter} size="sm" />
+                <div className="flex items-center gap-1.5 bg-black/55 backdrop-blur-sm rounded-lg px-2 py-1">
+                  {grade && <GradeImage grade={grade} className="w-7 h-7 drop-shadow" />}
+                  {score && (
+                    <span key={`${i}-${activeLb}`} className="text-base leading-none drop-shadow" style={{ ...SCORE_FONT, color: lbColor, ...FADE_IN }}>
+                      {score}
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/pages/widget/panels/SessionPanel.tsx
+++ b/frontend/src/pages/widget/panels/SessionPanel.tsx
@@ -1,0 +1,181 @@
+/* eslint-disable formatjs/no-literal-string-in-jsx */
+import React, { useState, useEffect } from 'react';
+import type { WidgetSession } from '../../../schemas/apiSchemas';
+import { PANEL_WIDTH, PANEL_HEIGHT, COMPACT_HEIGHTS, HORIZONTAL_WIDTHS } from '../../../utils/widgetConfig';
+import { GradeImage } from '../../../components/GradeImage';
+
+const HEADER_H = 28;
+const FADE_IN: React.CSSProperties = { animation: 'widgetFadeIn 0.4s ease' };
+const DURATION_FONT: React.CSSProperties = { fontFamily: "'Nunito', sans-serif", fontWeight: 800 };
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+function formatSteps(n: number): string {
+  if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+interface Props {
+  session: WidgetSession | null | undefined;
+  orientation: 'horizontal' | 'vertical';
+}
+
+export const SessionPanel: React.FC<Props> = ({ session, orientation }) => {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    if (!session?.isOngoing) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [session?.isOngoing]);
+
+  const isLive = session?.isOngoing ?? false;
+  const quads = session?.quads ?? 0;
+  const quints = session?.quints ?? 0;
+  const hexes = session?.hexes ?? 0;
+  const hasPerfects = quads > 0 || quints > 0 || hexes > 0;
+
+  const durationMs = session
+    ? session.isOngoing
+      ? now - new Date(session.startedAt).getTime()
+      : new Date(session.endedAt).getTime() - new Date(session.startedAt).getTime()
+    : 0;
+
+  const timerClass = isLive ? 'text-success' : 'text-primary/70';
+
+  const header = (
+    <div
+      style={{ height: HEADER_H }}
+      className="relative flex items-center justify-between px-3 flex-shrink-0 bg-base-300/80 z-10 border-b border-base-content/10"
+    >
+      <span className="text-[11px] font-semibold text-base-content/75 tracking-wide">Session</span>
+      {isLive ? (
+        <span className="flex items-center gap-1 text-[9px] font-bold px-2 py-0.5 rounded-full text-success bg-success/15">
+          <span className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />
+          LIVE
+        </span>
+      ) : session ? (
+        <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full text-primary/60 bg-primary/10">ended</span>
+      ) : null}
+    </div>
+  );
+
+  if (orientation === 'vertical') {
+    return (
+      <div
+        style={{ width: PANEL_WIDTH, height: COMPACT_HEIGHTS.currentSession }}
+        className="relative flex flex-col overflow-hidden border-b border-base-content/10 bg-base-200"
+      >
+        <div className="absolute left-0 top-0 h-full w-0.5 bg-gradient-to-b from-transparent via-primary/50 to-transparent z-10" />
+        {header}
+        {session ? (
+          <div key={String(isLive)} className="flex-1 flex items-center gap-0 px-3" style={FADE_IN}>
+            <div className="flex flex-col items-center px-2">
+              <span className={`text-sm leading-none tabular-nums ${timerClass}`} style={DURATION_FONT}>
+                {formatDuration(durationMs)}
+              </span>
+              <span className="text-[8px] text-base-content/50 uppercase tracking-wide mt-0.5">Time</span>
+            </div>
+            <div className="w-px h-6 bg-base-content/10 mx-1 flex-shrink-0" />
+            <div className="flex items-center justify-around flex-1">
+              <div className="flex flex-col items-center">
+                <span className="text-sm font-bold text-primary leading-none">{session.playCount}</span>
+                <span className="text-[8px] text-base-content/50 uppercase tracking-wide mt-0.5">Plays</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <span className="text-sm font-bold text-primary leading-none">{session.distinctCharts}</span>
+                <span className="text-[8px] text-base-content/50 uppercase tracking-wide mt-0.5">Charts</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <span className="text-sm font-bold text-primary leading-none">{formatSteps(session.stepsHit)}</span>
+                <span className="text-[8px] text-base-content/50 uppercase tracking-wide mt-0.5">Steps</span>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-xs text-base-content/40">No active session</div>
+        )}
+      </div>
+    );
+  }
+
+  // Horizontal
+  const W = HORIZONTAL_WIDTHS.currentSession;
+  const bodyH = PANEL_HEIGHT - HEADER_H;
+
+  return (
+    <div style={{ width: W, height: PANEL_HEIGHT }} className="relative flex flex-col overflow-hidden bg-base-200">
+      <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-accent/10 pointer-events-none" />
+      <div className="absolute top-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent z-10" />
+      <div className="absolute bottom-0 left-0 w-full h-px bg-gradient-to-r from-transparent via-base-content/10 to-transparent z-10" />
+      {header}
+
+      {session ? (
+        <div key={String(isLive)} style={{ height: bodyH, ...FADE_IN }} className="flex flex-col items-center justify-center gap-4 px-3">
+          {/* Timer */}
+          <div className="flex flex-col items-center gap-1">
+            <span className={`leading-none tabular-nums ${timerClass}`} style={{ fontSize: '2rem', ...DURATION_FONT }}>
+              {formatDuration(durationMs)}
+            </span>
+            <span className="text-[9px] font-semibold text-base-content/50 uppercase tracking-widest">Duration</span>
+          </div>
+
+          {/* Main stats */}
+          <div className="flex items-center justify-around w-full">
+            <div className="flex flex-col items-center gap-0.5">
+              <span className="text-lg font-bold text-primary leading-none">{session.playCount}</span>
+              <span className="text-[9px] text-base-content/50 uppercase tracking-wide">Plays</span>
+            </div>
+            <div className="w-px h-7 bg-base-content/10" />
+            <div className="flex flex-col items-center gap-0.5">
+              <span className="text-lg font-bold text-primary leading-none">{session.distinctCharts}</span>
+              <span className="text-[9px] text-base-content/50 uppercase tracking-wide">Charts</span>
+            </div>
+            <div className="w-px h-7 bg-base-content/10" />
+            <div className="flex flex-col items-center gap-0.5">
+              <span className="text-lg font-bold text-primary leading-none">{formatSteps(session.stepsHit)}</span>
+              <span className="text-[9px] text-base-content/50 uppercase tracking-wide">Steps</span>
+            </div>
+          </div>
+
+          {/* Perfect score counts — only rendered when non-zero */}
+          {hasPerfects && (
+            <div className="flex items-center gap-3">
+              {quads > 0 && (
+                <span className="flex items-center gap-1">
+                  <GradeImage grade="quad" className="w-5 h-5" />
+                  <span className="text-sm font-bold text-base-content">{quads}</span>
+                </span>
+              )}
+              {quints > 0 && (
+                <span className="flex items-center gap-1">
+                  <GradeImage grade="quint" className="w-5 h-5" />
+                  <span className="text-sm font-bold text-base-content">{quints}</span>
+                </span>
+              )}
+              {hexes > 0 && (
+                <span className="flex items-center gap-1">
+                  <GradeImage grade="hex" className="w-5 h-5" />
+                  <span className="text-sm font-bold text-base-content">{hexes}</span>
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div style={{ height: bodyH }} className="flex items-center justify-center text-sm text-base-content/40">
+          No active session
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/schemas/apiSchemas.ts
+++ b/frontend/src/schemas/apiSchemas.ts
@@ -222,6 +222,52 @@ export type SuccessResponse = z.infer<typeof successResponseSchema>;
 export type PackListItem = z.infer<typeof packListItemSchema>;
 export type ListPacksResponse = z.infer<typeof listPacksResponseSchema>;
 
+// Pack player scores schemas
+export const packPlayerScoreEntrySchema = z.object({
+  score: z.string(),
+  grade: z.string(),
+});
+
+export const packPlayerChartScoresSchema = z.record(
+  z.string(),
+  z.object({
+    EX: packPlayerScoreEntrySchema.optional(),
+    ITG: packPlayerScoreEntrySchema.optional(),
+    HardEX: packPlayerScoreEntrySchema.optional(),
+  }),
+);
+
+export const packPlayerScoreSimfileSchema = z.object({
+  simfileId: z.string(),
+  title: z.string(),
+  artist: z.string().nullable(),
+  bannerUrl: z.string().nullable(),
+  mdBannerUrl: z.string().nullable().optional(),
+  smBannerUrl: z.string().nullable().optional(),
+  bannerVariants: bannerVariantsSchema,
+  charts: z.object({
+    medium: z.object({ hash: z.string(), meter: z.number().nullable(), stepsType: z.string().nullable() }).optional(),
+    hard: z.object({ hash: z.string(), meter: z.number().nullable(), stepsType: z.string().nullable() }).optional(),
+    challenge: z.object({ hash: z.string(), meter: z.number().nullable(), stepsType: z.string().nullable() }).optional(),
+  }),
+});
+
+export const packPlayerScoresPlayerSchema = z.object({
+  userId: z.string(),
+  alias: z.string(),
+  profileImageUrl: z.string().nullable(),
+  scores: packPlayerChartScoresSchema,
+});
+
+export const packPlayerScoresResponseSchema = z.object({
+  simfiles: z.array(packPlayerScoreSimfileSchema),
+  players: z.array(packPlayerScoresPlayerSchema),
+});
+
+export type PackPlayerScoresResponse = z.infer<typeof packPlayerScoresResponseSchema>;
+export type PackPlayerScoreSimfile = z.infer<typeof packPlayerScoreSimfileSchema>;
+export type PackPlayerScoresPlayer = z.infer<typeof packPlayerScoresPlayerSchema>;
+
 // User list schemas (for Browse Users)
 export const userListItemSchema = z.object({
   id: z.string(),
@@ -1150,15 +1196,38 @@ export const widgetRecentPlaySchema = z.object({
   createdAt: z.union([z.string(), z.date()]),
 });
 
+export const widgetPackLeaderboardNearbyEntrySchema = z.object({
+  userId: z.string(),
+  alias: z.string(),
+  rank: z.number(),
+  totalScore: z.number(),
+  isRival: z.boolean(),
+  isSelf: z.boolean(),
+});
+
 export const widgetPackLeaderboardEntrySchema = z.object({
   rank: z.number(),
   totalScore: z.number(),
   totalParticipants: z.number(),
+  nearby: z.array(widgetPackLeaderboardNearbyEntrySchema).optional(),
 });
 
 export const widgetPackLeaderboardSchema = z.object({
   packName: z.string(),
+  difficulty: z.string().optional(),
   leaderboards: z.record(z.string(), widgetPackLeaderboardEntrySchema),
+});
+
+export const widgetSessionSchema = z.object({
+  startedAt: z.string(),
+  endedAt: z.string(),
+  playCount: z.number(),
+  distinctCharts: z.number(),
+  stepsHit: z.number(),
+  isOngoing: z.boolean(),
+  quads: z.number().optional().default(0),
+  quints: z.number().optional().default(0),
+  hexes: z.number().optional().default(0),
 });
 
 export const widgetDataResponseSchema = z.object({
@@ -1166,14 +1235,17 @@ export const widgetDataResponseSchema = z.object({
     id: z.string(),
     alias: z.string(),
     profileImageUrl: z.string().nullable(),
+    countryCode: z.string().nullable().optional(),
   }),
   recentPlays: z.array(widgetRecentPlaySchema).optional(),
   packLeaderboards: z.record(z.string(), widgetPackLeaderboardSchema).optional(),
+  currentSession: widgetSessionSchema.nullable().optional(),
 });
 
 export type WidgetDataResponse = z.infer<typeof widgetDataResponseSchema>;
 export type WidgetRecentPlay = z.infer<typeof widgetRecentPlaySchema>;
 export type WidgetPackLeaderboard = z.infer<typeof widgetPackLeaderboardSchema>;
+export type WidgetSession = z.infer<typeof widgetSessionSchema>;
 export type WidgetPackLeaderboardEntry = z.infer<typeof widgetPackLeaderboardEntrySchema>;
 
 // ----- Notification schemas -----

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -47,6 +47,8 @@ import {
   type BlueShiftAllPhasesResponse,
   type BlueShiftOverallSummary,
   type PackRecentPlay,
+  packPlayerScoresResponseSchema,
+  type PackPlayerScoresResponse,
   listApiKeysResponseSchema,
   createApiKeyResponseSchema,
   type ListApiKeysResponse,
@@ -417,6 +419,11 @@ export const getPackRecentPlays = async (packId: number, params: GetPackRecentPl
 
   const response = await api.get(`/pack/${packId}/recent-plays?${searchParams.toString()}`);
   return response.data as GetPackRecentPlaysResponse;
+};
+
+export const getPackPlayerScores = async (packId: number | string, userIds: string[]): Promise<PackPlayerScoresResponse> => {
+  const response = await api.get(`/pack/${packId}/player-scores?userIds=${userIds.join(',')}`);
+  return validateResponse<PackPlayerScoresResponse>(packPlayerScoresResponseSchema, response.data, `/pack/${packId}/player-scores`);
 };
 
 // Chart API functions

--- a/frontend/src/utils/widgetConfig.ts
+++ b/frontend/src/utils/widgetConfig.ts
@@ -2,7 +2,6 @@ export type LeaderboardKey = 'HardEX' | 'EX' | 'ITG';
 export type PackLeaderboardDifficulty = 'medium' | 'hard' | 'challenge';
 
 export type WidgetFeatureConfig =
-  | { type: 'profile' }
   | { type: 'recentPlays'; leaderboards: LeaderboardKey[] }
   | {
       type: 'packLeaderboard';
@@ -11,7 +10,8 @@ export type WidgetFeatureConfig =
       bannerUrl: string | null;
       difficulty: PackLeaderboardDifficulty;
       leaderboards: LeaderboardKey[];
-    };
+    }
+  | { type: 'currentSession' };
 
 export interface WidgetConfig {
   version: 1;
@@ -22,19 +22,21 @@ export interface WidgetConfig {
 export const PANEL_WIDTH = 300;
 export const PANEL_HEIGHT = 240;
 
-// Compact heights used in vertical orientation — each feature type gets a strip
+// Height of the always-present profile header band at the top of every widget
+export const PROFILE_HEADER_H = 48;
+
 // Compact heights for vertical orientation strips
 export const COMPACT_HEIGHTS: Record<WidgetFeatureConfig['type'], number> = {
-  profile: 60,
   recentPlays: 144,
   packLeaderboard: 80,
+  currentSession: 80,
 };
 
-// Panel widths for horizontal orientation (profile is narrower — it's just avatar + name)
+// Panel widths for horizontal orientation
 export const HORIZONTAL_WIDTHS: Record<WidgetFeatureConfig['type'], number> = {
-  profile: 140,
   recentPlays: 300,
   packLeaderboard: 235,
+  currentSession: 220,
 };
 
 export const ELIGIBLE_PACK_IDS = [101, 102, 131, 346, 348];
@@ -52,11 +54,13 @@ export function decodeWidgetConfig(encoded: string): WidgetConfig | null {
 }
 
 export function getWidgetDimensions(config: WidgetConfig): { width: number; height: number } {
+  // Filter out legacy 'profile' type from old encoded configs
+  const features = config.features.filter((f) => (f as any).type !== 'profile');
+
   if (config.orientation === 'horizontal') {
-    const width = config.features.reduce((sum, f) => sum + HORIZONTAL_WIDTHS[f.type], 0) || PANEL_WIDTH;
-    return { width, height: PANEL_HEIGHT };
+    const width = features.reduce((sum, f) => sum + (HORIZONTAL_WIDTHS[f.type] ?? 0), 0) || PANEL_WIDTH;
+    return { width, height: PANEL_HEIGHT + PROFILE_HEADER_H };
   }
-  // Vertical: sum compact heights per feature type
-  const height = config.features.reduce((sum, f) => sum + COMPACT_HEIGHTS[f.type], 0) || PANEL_HEIGHT;
-  return { width: PANEL_WIDTH, height };
+  const height = features.reduce((sum, f) => sum + (COMPACT_HEIGHTS[f.type] ?? 0), 0) || PANEL_HEIGHT;
+  return { width: PANEL_WIDTH, height: height + PROFILE_HEADER_H };
 }


### PR DESCRIPTION
Streamer widget:
- New "Current Session" panel showing a live session timer with play count, distinct charts, steps hit, and perfect scores (quads/quints/ hexes). Widget API returns currentSession data and the user-stats SQS consumer broadcasts a `sessionUpdate` WS event after writing a session.
- Replace the standalone `profile` feature with an always-present profile header band (with country code); filter the legacy `profile` type from old encoded configs. Add nearby-players (self + rivals + neighbors) to the pack leaderboard widget.
- Split the generic `refresh` WS message into granular `playSubmitted` and `sessionUpdate` events so panels refresh only what changed.
- Tighten session responsiveness: session gap 2h -> 1h and SQS batching window 5s -> 0s.

Pack player scores / compare:
- New GET /pack/{packId}/player-scores endpoint returning per-player best scores across ITG/EX/HardEX for every chart in the pack.
- New PackScoresPage with /pack/:packId/player/:userId and /pack/:packId/compare routes; pack leaderboard rows now link to it.